### PR TITLE
Update Humanize RLCR startup docs

### DIFF
--- a/skills/sglang-sota-humanize-loop/SKILL.md
+++ b/skills/sglang-sota-humanize-loop/SKILL.md
@@ -280,7 +280,7 @@ From the SGLang checkout, run:
 
 ```bash
 "$HUMANIZE_RUNTIME_ROOT/scripts/setup-rlcr-loop.sh" \
-  .humanize/sglang-sota-agent/refined-plan.md --yolo --strict-success
+  .humanize/sglang-sota-agent/refined-plan.md --yolo
 ```
 
 If `HUMANIZE_RUNTIME_ROOT` is not already set by the client/plugin environment,
@@ -293,16 +293,19 @@ After setup succeeds:
 
 1. Find the active state file with
    `find .humanize/rlcr -maxdepth 2 -name state.md -print`.
-2. Verify the state file exists and contains `strict_success: true`.
-3. Read `.humanize/rlcr/<timestamp>/round-0-prompt.md`.
-4. Execute the current round.
-5. Commit SGLang changes.
-6. Write the required Humanize round summary.
-7. Stop normally so the native Humanize Stop hook can review.
+2. Verify the state file exists, contains `current_round: 0`, and contains
+   `ask_codex_question: false` when using `--yolo`.
+3. Verify `.humanize/rlcr/<timestamp>/round-0-prompt.md` exists and includes
+   the generated Round Contract Setup instructions.
+4. Read `.humanize/rlcr/<timestamp>/round-0-prompt.md`.
+5. Execute the current round.
+6. Commit SGLang changes.
+7. Write the required Humanize round summary.
+8. Stop normally so the native Humanize Stop hook can review.
 
-If no active state file exists, or if `strict_success: true` is missing, stop
-and report that RLCR did not start correctly. Do not continue into SGLang patch
-work outside the Humanize loop. If the hook blocks exit, follow the generated
+If no active state file exists, or if `round-0-prompt.md` is missing, stop and
+report that RLCR did not start correctly. Do not continue into SGLang patch work
+outside the Humanize loop. If the hook blocks exit, follow the generated
 next-round prompt exactly.
 
 ## Inside Each RLCR Round

--- a/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
+++ b/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
@@ -155,8 +155,9 @@ source-path selection.
       paths, rejected source ideas, and the next planned SGLang patch.
     - The campaign can resume from the same model-loop artifacts with benchmark,
       profile, source-evidence, and patch lineage intact.
-    - The active `.humanize/rlcr/<timestamp>/state.md` exists and records
-      `strict_success: true` for the model-level SGLang loop.
+    - The active `.humanize/rlcr/<timestamp>/state.md` exists for the
+      model-level SGLang loop, and the matching `round-0-prompt.md` contains the
+      generated Round Contract Setup instructions.
   - Negative Tests (expected to FAIL):
     - A second `.humanize/rlcr` session is launched for kernel work instead of
       keeping the work in the model loop.
@@ -243,8 +244,9 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
 ## Implementation Notes
 
 - Keep Humanize local state under `.humanize/`.
-- Start RLCR with `--strict-success` and verify the active `state.md` contains
-  `strict_success: true` before any SGLang patch work.
+- Start RLCR with `--yolo`; verify the active `state.md` contains
+  `current_round: 0` and `ask_codex_question: false`, and verify
+  `round-0-prompt.md` exists before any SGLang patch work.
 - Keep benchmark/profile artifacts under `<artifact-root>`.
 - Keep the framework-selection contract in `<artifact-root>/manifest.md`, and
   update it only when the user changes the target/comparison framework set.

--- a/skills/vllm-sota-humanize-loop/SKILL.md
+++ b/skills/vllm-sota-humanize-loop/SKILL.md
@@ -237,7 +237,7 @@ From the vLLM checkout, run:
 
 ```bash
 "$HUMANIZE_RUNTIME_ROOT/scripts/setup-rlcr-loop.sh" \
-  .humanize/vllm-sota-agent/refined-plan.md --yolo --strict-success
+  .humanize/vllm-sota-agent/refined-plan.md --yolo
 ```
 
 If `HUMANIZE_RUNTIME_ROOT` is not already set by the client/plugin environment,
@@ -250,16 +250,19 @@ After setup succeeds:
 
 1. Find the active state file with
    `find .humanize/rlcr -maxdepth 2 -name state.md -print`.
-2. Verify the state file exists and contains `strict_success: true`.
-3. Read `.humanize/rlcr/<timestamp>/round-0-prompt.md`.
-4. Execute the current round.
-5. Commit vLLM changes.
-6. Write the required Humanize round summary.
-7. Stop normally so the native Humanize Stop hook can review.
+2. Verify the state file exists, contains `current_round: 0`, and contains
+   `ask_codex_question: false` when using `--yolo`.
+3. Verify `.humanize/rlcr/<timestamp>/round-0-prompt.md` exists and includes
+   the generated Round Contract Setup instructions.
+4. Read `.humanize/rlcr/<timestamp>/round-0-prompt.md`.
+5. Execute the current round.
+6. Commit vLLM changes.
+7. Write the required Humanize round summary.
+8. Stop normally so the native Humanize Stop hook can review.
 
-If no active state file exists, or if `strict_success: true` is missing, stop
-and report that RLCR did not start correctly. Do not continue into vLLM patch
-work outside the Humanize loop. If the hook blocks exit, follow the generated
+If no active state file exists, or if `round-0-prompt.md` is missing, stop and
+report that RLCR did not start correctly. Do not continue into vLLM patch work
+outside the Humanize loop. If the hook blocks exit, follow the generated
 next-round prompt exactly.
 
 ## Inside Each RLCR Round

--- a/skills/vllm-sota-humanize-loop/references/refined-plan-template.md
+++ b/skills/vllm-sota-humanize-loop/references/refined-plan-template.md
@@ -133,8 +133,9 @@ records the vLLM/SGLang PR evidence that influenced source-path selection.
       next planned vLLM patch.
     - The campaign can resume from the same model-loop artifacts with benchmark,
       profile, source-evidence, and patch lineage intact.
-    - The active `.humanize/rlcr/<timestamp>/state.md` exists and records
-      `strict_success: true` for the model-level vLLM loop.
+    - The active `.humanize/rlcr/<timestamp>/state.md` exists for the
+      model-level vLLM loop, and the matching `round-0-prompt.md` contains the
+      generated Round Contract Setup instructions.
   - Negative Tests (expected to FAIL):
     - A second `.humanize/rlcr` session is launched for kernel work instead of
       keeping the work in the model loop.
@@ -208,8 +209,9 @@ unless the current in-loop evidence proves no patch is needed.
 ## Implementation Notes
 
 - Keep Humanize local state under `.humanize/`.
-- Start RLCR with `--strict-success` and verify the active `state.md` contains
-  `strict_success: true` before any vLLM patch work.
+- Start RLCR with `--yolo`; verify the active `state.md` contains
+  `current_round: 0` and `ask_codex_question: false`, and verify
+  `round-0-prompt.md` exists before any vLLM patch work.
 - Keep benchmark/profile artifacts under `<artifact-root>`.
 - Keep model PR history notes under `<artifact-root>/history/`.
 - Keep layer-pipeline reports under `<artifact-root>/analysis/`.

--- a/tests/test_sota_humanize_loop_docs.py
+++ b/tests/test_sota_humanize_loop_docs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOTA_SKILL_ROOTS = [
+    ROOT / "skills" / "sglang-sota-humanize-loop",
+    ROOT / "skills" / "vllm-sota-humanize-loop",
+]
+REMOVED_STRICT_FLAG = "--strict" "-success"
+REMOVED_STRICT_STATE = "strict" "_success"
+
+
+class SotaHumanizeLoopDocsTest(unittest.TestCase):
+    def test_rlcr_startup_uses_supported_humanize_options(self) -> None:
+        for skill_root in SOTA_SKILL_ROOTS:
+            with self.subTest(skill=skill_root.name):
+                skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+
+                self.assertIn("setup-rlcr-loop.sh", skill)
+                self.assertIn("--yolo", skill)
+                self.assertNotIn(REMOVED_STRICT_FLAG, skill)
+                self.assertNotIn(REMOVED_STRICT_STATE, skill)
+
+    def test_refined_plan_templates_do_not_require_removed_strict_state(self) -> None:
+        for skill_root in SOTA_SKILL_ROOTS:
+            with self.subTest(skill=skill_root.name):
+                template = (
+                    skill_root / "references" / "refined-plan-template.md"
+                ).read_text(encoding="utf-8")
+
+                self.assertNotIn(REMOVED_STRICT_FLAG, template)
+                self.assertNotIn(REMOVED_STRICT_STATE, template)
+                self.assertIn("current_round: 0", template)
+                self.assertIn("ask_codex_question: false", template)
+                self.assertIn("round-0-prompt.md", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove the removed `--strict-success` option from SGLang/vLLM SOTA Humanize RLCR startup commands
- update post-setup validation to check the current Humanize state/prompt artifacts instead of the removed `strict_success` state field
- add regression coverage so SOTA loop docs/templates do not reintroduce the stale option

## Validation
- confirmed local `~/.codex/skills/humanize/scripts/setup-rlcr-loop.sh --help` has `--yolo` but no `--strict-success`
- `rg -n "strict-success|strict_success" .` returns no matches
- `python3 -m pytest tests` -> 118 passed