### PR TITLE
Add SGLang upgrade readiness auditor skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
     {
       "name": "ai-infra-auto-driven-skills",
       "source": "./",
-      "description": "LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
+      "description": "LLM serving benchmarks, SGLang upgrade readiness audits, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
       "version": "0.1.0",
       "category": "ai-infra",
-      "tags": ["sglang", "vllm", "tensorrt-llm", "benchmarks", "profiler", "kernel", "moe", "llm-serving"]
+      "tags": ["sglang", "vllm", "tensorrt-llm", "benchmarks", "upgrade", "profiler", "kernel", "moe", "llm-serving"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-infra-auto-driven-skills",
   "version": "0.1.0",
-  "description": "Agent-ready playbooks for LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
+  "description": "Agent-ready playbooks for LLM serving benchmarks, SGLang upgrade readiness auditing, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
   "author": {
     "name": "BBuf",
     "url": "https://github.com/BBuf"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # AI-Infra-Auto-Driven-SKILLS
 
-**Agent-ready playbooks for LLM serving benchmarks, capacity planning,
-torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM
-optimization, human code review, production incidents, and model PR
-intelligence.**
+**Agent-ready playbooks for LLM serving benchmarks, SGLang upgrade auditing,
+capacity planning, torch-profiler triage, pipeline analysis, compute
+simulation, SGLang/vLLM optimization, human code review, production incidents,
+and model PR intelligence.**
 
 [![GitHub stars](https://img.shields.io/github/stars/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/forks)
 [![Last commit](https://img.shields.io/github/last-commit/BBuf/AI-Infra-Auto-Driven-SKILLS?style=flat-square)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/commits/main)
-[![Core skills](https://img.shields.io/badge/core_skills-11-2f80ed?style=flat-square)](#core-skills)
+[![Core skills](https://img.shields.io/badge/core_skills-12-2f80ed?style=flat-square)](#core-skills)
 [![PR histories](https://img.shields.io/badge/pr_histories-66-2ea44f?style=flat-square)](#model-pr-history-catalog)
 [![KDA-Pilot](https://img.shields.io/badge/sibling-KDA--Pilot-ff7b72?style=flat-square)](https://github.com/BBuf/KDA-Pilot)
 
@@ -20,12 +20,14 @@ This repository is built for AI infrastructure engineers who want agents to do
 real work, not recite generic prompts.
 
 It gives an agent the operational memory needed to benchmark SGLang, vLLM,
-TensorRT-LLM, and TokenSpeed fairly; explain serving capacity from startup logs;
-split prefill and decode profiler evidence; inspect traces at layer and kernel
-level; estimate operator FLOPs and MFU; review SGLang patches against real
-maintainer discussion patterns; run Humanize-governed SGLang and vLLM SOTA
-loops; triage SGLang production incidents from a replay; and keep model-family
-optimization history close to the code that actually changed.
+TensorRT-LLM, and TokenSpeed fairly; audit SGLang upgrades against real launch
+profiles, breaking changes, known issues, and canary requirements; explain
+serving capacity from startup logs; split prefill and decode profiler evidence;
+inspect traces at layer and kernel level; estimate operator FLOPs and MFU;
+review SGLang patches against real maintainer discussion patterns; run
+Humanize-governed SGLang and vLLM SOTA loops; triage SGLang production
+incidents from a replay; and keep model-family optimization history close to
+the code that actually changed.
 
 For standalone kernel campaigns and kernel evidence tools, see the sibling
 project **[KDA-Pilot](https://github.com/BBuf/KDA-Pilot)**.
@@ -39,6 +41,7 @@ find it.
 | Skill | Use it when |
 | --- | --- |
 | [`llm-serving-auto-benchmark`](skills/llm-serving-auto-benchmark/) | You need a fair, bounded serving benchmark search for SGLang, vLLM, TensorRT-LLM, TokenSpeed, or another OpenAI-compatible stack. |
+| [`sglang-upgrade-readiness-auditor`](skills/sglang-upgrade-readiness-auditor/) | You need to match an SGLang version interval against actual launch profiles, propose safe argv/import migrations, and produce GO/CONDITIONAL_GO/NO_GO decisions with canaries and rollback. |
 | [`llm-serving-capacity-planner`](skills/llm-serving-capacity-planner/) | You need to explain SGLang or vLLM startup memory, KV cache budget, request capacity, or OOM pressure from logs. |
 | [`llm-torch-profiler-analysis`](skills/llm-torch-profiler-analysis/) | You need a three-table profiler report that keeps `extend/prefill` and `decode` evidence separate. |
 | [`llm-pipeline-analysis`](skills/llm-pipeline-analysis/) | You need forward-pass, layer, and kernel-level timing from a torch profiler trace, including anchor boundaries and Perfetto ranges. |
@@ -128,6 +131,9 @@ The repo is opinionated about evidence because performance work gets noisy fast.
 - Benchmark rows should include model, framework, GPU count, workload, request
   rate or concurrency, SLA status, launch command, benchmark command, and raw
   artifacts.
+- Upgrade audits should resolve immutable version endpoints, match
+  source-linked changes to actual argv/profile evidence, and require target
+  canaries before a `GO`.
 - Profiler reports should keep prefill and decode separate, then emit the same
   three tables: kernel table, overlap-opportunity table, and fuse-opportunity
   table.
@@ -169,7 +175,7 @@ installed as a single Claude Code plugin via the built-in marketplace flow:
 /reload-plugins
 ```
 
-After reload, the 12 skills appear namespaced as
+After reload, the 13 skills appear namespaced as
 `ai-infra-auto-driven-skills:<skill-name>` (for example
 `ai-infra-auto-driven-skills:sglang-sota-humanize-loop`). Update later with
 `/plugin marketplace update ai-infra-auto-driven-skills`.
@@ -186,6 +192,7 @@ cd AI-Infra-Auto-Driven-SKILLS
 
 mkdir -p ~/.claude/skills
 ln -s "$PWD/skills/llm-serving-auto-benchmark" ~/.claude/skills/llm-serving-auto-benchmark
+ln -s "$PWD/skills/sglang-upgrade-readiness-auditor" ~/.claude/skills/sglang-upgrade-readiness-auditor
 ln -s "$PWD/skills/llm-serving-capacity-planner" ~/.claude/skills/llm-serving-capacity-planner
 ln -s "$PWD/skills/llm-torch-profiler-analysis" ~/.claude/skills/llm-torch-profiler-analysis
 ln -s "$PWD/skills/llm-pipeline-analysis" ~/.claude/skills/llm-pipeline-analysis
@@ -201,6 +208,7 @@ ln -s "$PWD/model-pr-optimization-history" ~/.claude/skills/model-pr-history-kno
 
 Restart Claude Code after installing. The skills can then be invoked by name,
 for example `[$llm-serving-auto-benchmark]`,
+`[$sglang-upgrade-readiness-auditor]`,
 `[$llm-serving-capacity-planner]`, `[$llm-torch-profiler-analysis]`,
 `[$llm-pipeline-analysis]`, `[$model-compute-simulation]`,
 `[$model-pr-diff-dossier]`, `[$sglang-humanize-review]`,
@@ -218,6 +226,7 @@ directories into that runtime's skill directory:
 
 ```bash
 cp -R skills/llm-serving-auto-benchmark <agent-skill-dir>/llm-serving-auto-benchmark
+cp -R skills/sglang-upgrade-readiness-auditor <agent-skill-dir>/sglang-upgrade-readiness-auditor
 cp -R skills/llm-serving-capacity-planner <agent-skill-dir>/llm-serving-capacity-planner
 cp -R skills/llm-torch-profiler-analysis <agent-skill-dir>/llm-torch-profiler-analysis
 cp -R skills/llm-pipeline-analysis <agent-skill-dir>/llm-pipeline-analysis
@@ -262,6 +271,7 @@ correctness gates.
 ```text
 skills/
 ├── llm-serving-auto-benchmark/      # serving benchmark search and comparison
+├── sglang-upgrade-readiness-auditor/ # version migration and canary audit
 ├── llm-serving-capacity-planner/     # startup memory and request capacity analysis
 ├── llm-torch-profiler-analysis/     # profiler capture and trace triage
 ├── llm-pipeline-analysis/           # forward/layer/kernel trace analysis

--- a/docs/superpowers/plans/2026-07-28-sglang-upgrade-readiness-auditor.md
+++ b/docs/superpowers/plans/2026-07-28-sglang-upgrade-readiness-auditor.md
@@ -1,0 +1,1035 @@
+# SGLang Upgrade Readiness Auditor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a read-only SGLang upgrade auditor that matches evidence-backed version changes against concrete deployment profiles, proposes safe argv rewrites, and emits per-profile and overall readiness verdicts with canary requirements.
+
+**Architecture:** `SKILL.md` owns source collection and rule authoring from immutable releases and diffs. A standard-library Python analyzer owns version applicability, deployment matching, conflict-safe argv transformations, verdict aggregation, and Markdown/JSON output. A synthetic v0.5.15-to-v0.5.16 fixture demonstrates removed paths, flag renames, behavior changes, and known risks.
+
+**Tech Stack:** Markdown, Python 3.10+ standard library, `unittest`, JSON, repository pre-commit and link checks.
+
+---
+
+## File Structure
+
+- Create `skills/sglang-upgrade-readiness-auditor/SKILL.md`: read-only inventory, evidence, audit, canary, verdict, and rollback workflow.
+- Create `skills/sglang-upgrade-readiness-auditor/references/evidence-and-rule-authoring.md`: source priority and rule-authoring guidance.
+- Create `skills/sglang-upgrade-readiness-auditor/references/profile-and-rule-schema.md`: exact JSON schemas and transformations.
+- Create `skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py`: validator, matcher, transformer, verdict engine, and reporters.
+- Create `skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json`: synthetic deployment inventory.
+- Create `skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json`: source-linked release rules.
+- Create `skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md`: generated demonstration.
+- Create `tests/test_upgrade_readiness_auditor.py`: version, matching, rewrite, verdict, report, fixture, and documentation tests.
+- Modify `README.md`: register the new core skill, installation commands, examples, and count.
+- Modify `.claude-plugin/plugin.json`: mention upgrade readiness auditing.
+- Modify `.claude-plugin/marketplace.json`: mention upgrade auditing in discovery metadata.
+- Modify `tests/test_repository_metadata.py`: update core-skill count and assert registration.
+
+### Task 1: Validate Versions, Profiles, and Rules
+
+**Files:**
+- Create: `tests/test_upgrade_readiness_auditor.py`
+- Create: `skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py`
+
+- [ ] **Step 1: Write failing version and schema tests**
+
+```python
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "skills"
+    / "sglang-upgrade-readiness-auditor"
+    / "scripts"
+    / "audit_upgrade.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("upgrade_auditor", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_profiles() -> dict:
+    return {
+        "schema_version": 1,
+        "fixture": True,
+        "audit": {
+            "current_version": "v0.5.15",
+            "target_version": "v0.5.16",
+            "required_canaries": ["server_health", "correctness", "performance"],
+        },
+        "profiles": [
+            {
+                "id": "plain-tp",
+                "argv": ["python3", "-m", "sglang.launch_server", "--model-path", "fixture/model", "--tp", "8"],
+                "env": {},
+                "model_family": "dense",
+                "quantization": "fp8",
+                "hardware": "b200",
+                "topology": {"tp": 8, "dp": 1, "ep": 1, "cp": 1},
+                "features": [],
+                "guarantees": [],
+                "integrations": [],
+                "imports": [],
+                "canary_results": {
+                    "server_health": "pass",
+                    "correctness": "pass",
+                    "performance": "pass"
+                },
+            }
+        ],
+    }
+
+
+def valid_rules() -> dict:
+    return {
+        "schema_version": 1,
+        "rules": [
+            {
+                "id": "rename-waterfill",
+                "category": "required_change",
+                "severity": "required",
+                "title": "Waterfill flag renamed",
+                "applies": {"introduced_in": "v0.5.16"},
+                "source_url": "https://github.com/sgl-project/sglang/pull/27350",
+                "summary": "The old flag has no deprecated alias.",
+                "match": {
+                    "all": [
+                        {"kind": "argv_flag", "name": "--enable-deepep-waterfill"}
+                    ]
+                },
+                "transforms": [
+                    {
+                        "kind": "rename_flag",
+                        "from": "--enable-deepep-waterfill",
+                        "to": "--enable-waterfill"
+                    }
+                ],
+                "canaries": ["server_health", "performance"],
+            }
+        ],
+    }
+
+
+class SchemaAndVersionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_versions_support_post_releases(self) -> None:
+        self.assertLess(
+            self.mod.parse_version("v0.5.15"),
+            self.mod.parse_version("v0.5.15.post1"),
+        )
+
+    def test_valid_documents_are_accepted(self) -> None:
+        self.mod.validate_profiles(valid_profiles())
+        self.mod.validate_rules(valid_rules())
+
+    def test_duplicate_profile_id_is_rejected(self) -> None:
+        document = valid_profiles()
+        document["profiles"].append(dict(document["profiles"][0]))
+        with self.assertRaisesRegex(ValueError, "duplicate profile id"):
+            self.mod.validate_profiles(document)
+
+    def test_unknown_transform_is_rejected(self) -> None:
+        rules = valid_rules()
+        rules["rules"][0]["transforms"][0]["kind"] = "execute_shell"
+        with self.assertRaisesRegex(ValueError, "unknown transform"):
+            self.mod.validate_rules(rules)
+```
+
+- [ ] **Step 2: Run tests and verify the module is missing**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.SchemaAndVersionTest -v
+```
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Implement parsing and schema validation**
+
+Create:
+
+```python
+#!/usr/bin/env python3
+"""Audit SGLang version changes against deployment profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+VERSION_RE = re.compile(r"^v?(\\d+)\\.(\\d+)\\.(\\d+)(?:\\.post(\\d+))?$")
+VALID_SEVERITIES = {"blocker", "required", "behavior", "risk", "dependency", "info"}
+VALID_TRANSFORMS = {"rename_flag", "remove_flag", "replace_value", "replace_import_prefix"}
+VALID_PREDICATES = {
+    "argv_flag",
+    "argv_value",
+    "env",
+    "feature",
+    "guarantee",
+    "integration",
+    "import_prefix",
+    "model_family",
+    "quantization",
+    "hardware",
+    "topology",
+}
+
+
+def parse_version(value: str) -> tuple[int, int, int, int]:
+    match = VERSION_RE.fullmatch(value)
+    if not match:
+        raise ValueError(f"unsupported SGLang version: {value}")
+    major, minor, patch, post = match.groups()
+    return int(major), int(minor), int(patch), int(post or 0)
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def validate_profiles(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("profile schema_version must be 1")
+    audit = document.get("audit")
+    profiles = document.get("profiles")
+    if not isinstance(audit, dict):
+        raise ValueError("audit must be an object")
+    current = parse_version(_require_string(audit.get("current_version"), "current_version"))
+    target = parse_version(_require_string(audit.get("target_version"), "target_version"))
+    if current >= target:
+        raise ValueError("target_version must be newer than current_version")
+    if not isinstance(profiles, list) or not profiles:
+        raise ValueError("profiles must be a non-empty array")
+    ids: set[str] = set()
+    for profile in profiles:
+        profile_id = _require_string(profile.get("id"), "profile id")
+        if profile_id in ids:
+            raise ValueError(f"duplicate profile id: {profile_id}")
+        ids.add(profile_id)
+        argv = profile.get("argv")
+        if not isinstance(argv, list) or not argv or not all(
+            isinstance(token, str) and token for token in argv
+        ):
+            raise ValueError(f"{profile_id}: argv must be a non-empty string array")
+        if not isinstance(profile.get("env", {}), dict):
+            raise ValueError(f"{profile_id}: env must be an object")
+
+
+def validate_rules(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("rule schema_version must be 1")
+    rules = document.get("rules")
+    if not isinstance(rules, list):
+        raise ValueError("rules must be an array")
+    ids: set[str] = set()
+    for rule in rules:
+        rule_id = _require_string(rule.get("id"), "rule id")
+        if rule_id in ids:
+            raise ValueError(f"duplicate rule id: {rule_id}")
+        ids.add(rule_id)
+        if rule.get("severity") not in VALID_SEVERITIES:
+            raise ValueError(f"{rule_id}: invalid severity")
+        parse_version(_require_string(rule.get("applies", {}).get("introduced_in"), f"{rule_id}.introduced_in"))
+        fixed_in = rule.get("applies", {}).get("fixed_in")
+        if fixed_in is not None:
+            parse_version(_require_string(fixed_in, f"{rule_id}.fixed_in"))
+        _require_string(rule.get("source_url"), f"{rule_id}.source_url")
+        predicates = rule.get("match", {}).get("all")
+        if not isinstance(predicates, list) or not predicates:
+            raise ValueError(f"{rule_id}: match.all must be non-empty")
+        for predicate in predicates:
+            if predicate.get("kind") not in VALID_PREDICATES:
+                raise ValueError(f"{rule_id}: unknown predicate")
+        for transform in rule.get("transforms", []):
+            if transform.get("kind") not in VALID_TRANSFORMS:
+                raise ValueError(f"{rule_id}: unknown transform")
+```
+
+- [ ] **Step 4: Run schema tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.SchemaAndVersionTest -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit schema boundaries**
+
+```bash
+git add tests/test_upgrade_readiness_auditor.py \
+  skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+git commit -m "feat: validate SGLang upgrade audit inputs"
+```
+
+### Task 2: Match Versioned Rules to Deployment Profiles
+
+**Files:**
+- Modify: `tests/test_upgrade_readiness_auditor.py`
+- Modify: `skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py`
+
+- [ ] **Step 1: Add failing applicability and predicate tests**
+
+```python
+class RuleMatchingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_rule_applies_when_upgrade_crosses_introduced_version(self) -> None:
+        rule = valid_rules()["rules"][0]
+        self.assertTrue(self.mod.rule_applies(rule, "v0.5.15", "v0.5.16"))
+        self.assertFalse(self.mod.rule_applies(rule, "v0.5.16", "v0.5.17"))
+
+    def test_fixed_known_issue_does_not_apply_to_fixed_target(self) -> None:
+        rule = valid_rules()["rules"][0]
+        rule["applies"]["fixed_in"] = "v0.5.17"
+        self.assertFalse(self.mod.rule_applies(rule, "v0.5.15", "v0.5.17"))
+
+    def test_all_predicates_must_match(self) -> None:
+        profile = valid_profiles()["profiles"][0]
+        rule = valid_rules()["rules"][0]
+        rule["match"]["all"] = [
+            {"kind": "hardware", "equals": "b200"},
+            {"kind": "topology", "name": "tp", "min": 8},
+            {"kind": "feature", "value": "breakable_prefill_cuda_graph"},
+        ]
+        self.assertFalse(self.mod.rule_matches(rule, profile))
+        profile["features"].append("breakable_prefill_cuda_graph")
+        self.assertTrue(self.mod.rule_matches(rule, profile))
+```
+
+- [ ] **Step 2: Run matching tests and verify missing functions**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.RuleMatchingTest -v
+```
+
+Expected: failures for missing `rule_applies` and `rule_matches`.
+
+- [ ] **Step 3: Implement version applicability**
+
+```python
+def rule_applies(rule: dict[str, Any], current: str, target: str) -> bool:
+    current_version = parse_version(current)
+    target_version = parse_version(target)
+    introduced = parse_version(rule["applies"]["introduced_in"])
+    if not (current_version < introduced <= target_version):
+        return False
+    fixed_in = rule["applies"].get("fixed_in")
+    return fixed_in is None or target_version < parse_version(fixed_in)
+```
+
+- [ ] **Step 4: Implement all supported predicates**
+
+Add helpers for locating flag values and:
+
+```python
+def _flag_index(argv: list[str], name: str) -> int | None:
+    try:
+        return argv.index(name)
+    except ValueError:
+        return None
+
+
+def _predicate_matches(predicate: dict[str, Any], profile: dict[str, Any]) -> bool:
+    kind = predicate["kind"]
+    if kind == "argv_flag":
+        return _flag_index(profile["argv"], predicate["name"]) is not None
+    if kind == "argv_value":
+        index = _flag_index(profile["argv"], predicate["name"])
+        return (
+            index is not None
+            and index + 1 < len(profile["argv"])
+            and profile["argv"][index + 1] == predicate["equals"]
+        )
+    if kind == "env":
+        value = profile.get("env", {}).get(predicate["name"])
+        return value == predicate.get("equals") if "equals" in predicate else value is not None
+    if kind in {"feature", "guarantee", "integration"}:
+        collection_name = {
+            "feature": "features",
+            "guarantee": "guarantees",
+            "integration": "integrations",
+        }[kind]
+        return predicate["value"] in profile.get(collection_name, [])
+    if kind == "import_prefix":
+        return any(
+            value == predicate["value"] or value.startswith(predicate["value"] + ".")
+            for value in profile.get("imports", [])
+        )
+    if kind in {"model_family", "quantization", "hardware"}:
+        return profile.get(kind) == predicate["equals"]
+    if kind == "topology":
+        value = profile.get("topology", {}).get(predicate["name"])
+        if not isinstance(value, int):
+            return False
+        if "equals" in predicate and value != predicate["equals"]:
+            return False
+        if "min" in predicate and value < predicate["min"]:
+            return False
+        if "max" in predicate and value > predicate["max"]:
+            return False
+        return True
+    raise ValueError(f"unsupported predicate: {kind}")
+
+
+def rule_matches(rule: dict[str, Any], profile: dict[str, Any]) -> bool:
+    return all(
+        _predicate_matches(predicate, profile)
+        for predicate in rule["match"]["all"]
+    )
+```
+
+- [ ] **Step 5: Run matching tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.RuleMatchingTest -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit rule matching**
+
+```bash
+git add tests/test_upgrade_readiness_auditor.py \
+  skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+git commit -m "feat: match upgrade rules to deployments"
+```
+
+### Task 3: Add Safe Transformations and Conflict Detection
+
+**Files:**
+- Modify: `tests/test_upgrade_readiness_auditor.py`
+- Modify: `skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py`
+
+- [ ] **Step 1: Add failing argv and import transformation tests**
+
+```python
+class TransformationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_rename_and_replace_value_are_token_level(self) -> None:
+        argv = [
+            "python3",
+            "-m",
+            "sglang.launch_server",
+            "--enable-deepep-waterfill",
+            "--fp4-gemm-backend",
+            "cutlass",
+        ]
+        transforms = [
+            {"kind": "rename_flag", "from": "--enable-deepep-waterfill", "to": "--enable-waterfill"},
+            {"kind": "replace_value", "flag": "--fp4-gemm-backend", "from": "cutlass", "to": "auto"},
+        ]
+        rewritten, imports = self.mod.apply_transforms(argv, [], transforms)
+        self.assertEqual(
+            rewritten,
+            [
+                "python3",
+                "-m",
+                "sglang.launch_server",
+                "--enable-waterfill",
+                "--fp4-gemm-backend",
+                "auto",
+            ],
+        )
+        self.assertEqual(imports, [])
+
+    def test_remove_flag_respects_arity(self) -> None:
+        rewritten, _ = self.mod.apply_transforms(
+            ["server", "--removed", "value", "--keep"],
+            [],
+            [{"kind": "remove_flag", "name": "--removed", "arity": 1}],
+        )
+        self.assertEqual(rewritten, ["server", "--keep"])
+
+    def test_conflicting_rewrites_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "conflicting transformations"):
+            self.mod.detect_transform_conflicts(
+                [
+                    {"kind": "rename_flag", "from": "--old", "to": "--new-a"},
+                    {"kind": "rename_flag", "from": "--old", "to": "--new-b"},
+                ]
+            )
+```
+
+- [ ] **Step 2: Run transformation tests and verify failure**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.TransformationTest -v
+```
+
+Expected: failures for missing transformation functions.
+
+- [ ] **Step 3: Implement conflict keys and transformations**
+
+Implement deterministic conflict keys and exact transformations:
+
+```python
+def _transform_key(transform: dict[str, Any]) -> tuple[str, str]:
+    kind = transform["kind"]
+    if kind == "rename_flag":
+        return "flag", transform["from"]
+    if kind == "remove_flag":
+        return "flag", transform["name"]
+    if kind == "replace_value":
+        return "flag_value", transform["flag"]
+    return "import", transform["from"]
+
+
+def detect_transform_conflicts(transforms: list[dict[str, Any]]) -> None:
+    seen: dict[tuple[str, str], str] = {}
+    for transform in transforms:
+        key = _transform_key(transform)
+        rendered = json.dumps(transform, sort_keys=True)
+        if key in seen and seen[key] != rendered:
+            raise ValueError(f"conflicting transformations for {key[1]}")
+        seen[key] = rendered
+
+
+def apply_transforms(
+    argv: list[str],
+    imports: list[str],
+    transforms: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    detect_transform_conflicts(transforms)
+    rewritten = list(argv)
+    rewritten_imports = list(imports)
+    for transform in transforms:
+        kind = transform["kind"]
+        if kind == "rename_flag":
+            index = _flag_index(rewritten, transform["from"])
+            if index is None:
+                raise ValueError(f"flag not found for rename: {transform['from']}")
+            rewritten[index] = transform["to"]
+        elif kind == "remove_flag":
+            index = _flag_index(rewritten, transform["name"])
+            if index is None:
+                raise ValueError(f"flag not found for removal: {transform['name']}")
+            arity = transform.get("arity", 0)
+            if arity not in {0, 1} or index + arity >= len(rewritten):
+                raise ValueError(f"invalid removal arity for {transform['name']}")
+            del rewritten[index : index + arity + 1]
+        elif kind == "replace_value":
+            index = _flag_index(rewritten, transform["flag"])
+            if (
+                index is None
+                or index + 1 >= len(rewritten)
+                or rewritten[index + 1] != transform["from"]
+            ):
+                raise ValueError(f"flag value not found for replacement: {transform['flag']}")
+            rewritten[index + 1] = transform["to"]
+        elif kind == "replace_import_prefix":
+            source = transform["from"]
+            target = transform["to"]
+            rewritten_imports = [
+                target + value[len(source) :]
+                if value == source or value.startswith(source + ".")
+                else value
+                for value in rewritten_imports
+            ]
+    return rewritten, rewritten_imports
+```
+
+- [ ] **Step 4: Run transformation tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.TransformationTest -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit safe rewrites**
+
+```bash
+git add tests/test_upgrade_readiness_auditor.py \
+  skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+git commit -m "feat: propose safe SGLang command rewrites"
+```
+
+### Task 4: Compute Verdicts and Render Reports
+
+**Files:**
+- Modify: `tests/test_upgrade_readiness_auditor.py`
+- Modify: `skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py`
+
+- [ ] **Step 1: Add failing verdict and report tests**
+
+```python
+class AuditVerdictTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_unmatched_profile_with_passing_base_canaries_is_go(self) -> None:
+        result = self.mod.audit(valid_profiles(), valid_rules())
+        self.assertEqual(result["profiles"][0]["verdict"], "GO")
+
+    def test_required_rewrite_is_conditional_go(self) -> None:
+        profiles = valid_profiles()
+        profiles["profiles"][0]["argv"].append("--enable-deepep-waterfill")
+        result = self.mod.audit(profiles, valid_rules())
+        profile = result["profiles"][0]
+        self.assertEqual(profile["verdict"], "CONDITIONAL_GO")
+        self.assertIn("--enable-waterfill", profile["proposed_argv"])
+
+    def test_unresolved_blocker_is_no_go(self) -> None:
+        profiles = valid_profiles()
+        profiles["profiles"][0]["features"].extend(
+            ["dp_attention", "breakable_prefill_cuda_graph"]
+        )
+        profiles["profiles"][0]["guarantees"].append("temperature_zero_determinism")
+        rules = valid_rules()
+        rules["rules"].append(
+            {
+                "id": "determinism-known-issue",
+                "category": "known_issue",
+                "severity": "blocker",
+                "title": "Temperature-zero nondeterminism",
+                "applies": {"introduced_in": "v0.5.16", "fixed_in": None},
+                "source_url": "https://github.com/sgl-project/sglang/pull/31125",
+                "summary": "Avoid the affected graph path.",
+                "match": {
+                    "all": [
+                        {"kind": "feature", "value": "dp_attention"},
+                        {"kind": "feature", "value": "breakable_prefill_cuda_graph"},
+                        {"kind": "guarantee", "value": "temperature_zero_determinism"}
+                    ]
+                },
+                "transforms": [],
+                "canaries": ["temperature_zero_determinism"]
+            }
+        )
+        result = self.mod.audit(profiles, rules)
+        self.assertEqual(result["profiles"][0]["verdict"], "NO_GO")
+        self.assertEqual(result["overall_verdict"], "NO_GO")
+
+    def test_markdown_never_executes_or_hides_commands(self) -> None:
+        result = self.mod.audit(valid_profiles(), valid_rules())
+        report = self.mod.render_markdown(result)
+        self.assertIn("SYNTHETIC FIXTURE", report)
+        self.assertIn("## Profile Verdicts", report)
+        self.assertIn("## Proposed Commands", report)
+        self.assertIn("python3 -m sglang.launch_server", report)
+```
+
+- [ ] **Step 2: Run verdict tests and verify missing behavior**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.AuditVerdictTest -v
+```
+
+Expected: failures for missing `audit` and `render_markdown`.
+
+- [ ] **Step 3: Implement audit aggregation**
+
+For every profile:
+
+1. filter rules with `rule_applies` and `rule_matches`;
+2. collect transformations and conflicts;
+3. preserve source-linked findings even when no transform exists;
+4. apply safe transforms;
+5. union base and matched-rule canaries;
+6. calculate missing/failing canaries;
+7. assign `NO_GO` for blockers or transform conflicts,
+   `CONDITIONAL_GO` for required/behavior/risk/dependency findings or missing
+   canaries, otherwise `GO`;
+8. aggregate overall verdict with `NO_GO > CONDITIONAL_GO > GO`.
+
+Implement the result shape:
+
+```python
+{
+    "schema_version": 1,
+    "fixture": True,
+    "current_version": "v0.5.15",
+    "target_version": "v0.5.16",
+    "overall_verdict": "CONDITIONAL_GO",
+    "profiles": [
+        {
+            "id": "legacy-pd",
+            "verdict": "CONDITIONAL_GO",
+            "original_argv": [],
+            "proposed_argv": [],
+            "original_imports": [],
+            "proposed_imports": [],
+            "findings": [],
+            "required_canaries": [],
+            "missing_or_failing_canaries": []
+        }
+    ]
+}
+```
+
+- [ ] **Step 4: Implement stable Markdown and CLI**
+
+Render:
+
+- fixture disclaimer;
+- version pair and overall verdict;
+- profile verdict table;
+- per-profile findings with severity, source URL, and summary;
+- original and proposed commands using `shlex.join`;
+- import rewrites;
+- required/missing canaries;
+- rollback conditions copied from rule guidance.
+
+Add CLI arguments:
+
+```python
+parser.add_argument("--profiles", required=True, type=Path)
+parser.add_argument("--rules", required=True, type=Path)
+parser.add_argument("--output-markdown", required=True, type=Path)
+parser.add_argument("--output-json", required=True, type=Path)
+```
+
+Load both roots as JSON objects, validate them, write stable sorted JSON and
+Markdown, return `2` on invalid input, and never execute any argv.
+
+- [ ] **Step 5: Run verdict, CLI, and all current tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor -v
+python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py --help
+```
+
+Expected: all tests pass and help exits zero.
+
+- [ ] **Step 6: Commit verdicts and reports**
+
+```bash
+git add tests/test_upgrade_readiness_auditor.py \
+  skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+git commit -m "feat: report SGLang upgrade readiness"
+```
+
+### Task 5: Add the v0.5.15-to-v0.5.16 Demonstration
+
+**Files:**
+- Create: `skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json`
+- Create: `skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json`
+- Create: `skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md`
+- Modify: `tests/test_upgrade_readiness_auditor.py`
+
+- [ ] **Step 1: Add a failing fixture reproducibility test**
+
+```python
+class FixtureDemoTest(unittest.TestCase):
+    def test_v0516_fixture_report_is_reproducible(self) -> None:
+        module = load_module()
+        root = ROOT / "skills" / "sglang-upgrade-readiness-auditor"
+        profiles = json.loads(
+            (root / "examples" / "v0.5.15-to-v0.5.16-profiles.json").read_text(encoding="utf-8")
+        )
+        rules = json.loads(
+            (root / "examples" / "v0.5.15-to-v0.5.16-rules.json").read_text(encoding="utf-8")
+        )
+        result = module.audit(profiles, rules)
+        report = module.render_markdown(result)
+        committed = (root / "examples" / "fixture-report.md").read_text(encoding="utf-8")
+        self.assertEqual(report, committed)
+        by_id = {profile["id"]: profile for profile in result["profiles"]}
+        self.assertEqual(by_id["plain-tp"]["verdict"], "GO")
+        self.assertEqual(by_id["legacy-fp4-pd"]["verdict"], "CONDITIONAL_GO")
+        self.assertEqual(by_id["deterministic-dp-graph"]["verdict"], "NO_GO")
+        self.assertEqual(result["overall_verdict"], "NO_GO")
+```
+
+- [ ] **Step 2: Run the fixture test and verify files are missing**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.FixtureDemoTest -v
+```
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Create three synthetic profiles**
+
+Create:
+
+- `plain-tp`: no affected features and passing base canaries;
+- `legacy-fp4-pd`: argv contains `--fp4-gemm-backend cutlass`,
+  `--enable-deepep-waterfill`, and `--optimistic-prefill-retries 3`;
+- `deterministic-dp-graph`: features include `dp_attention` and
+  `breakable_prefill_cuda_graph`, with
+  `temperature_zero_determinism` as a required guarantee.
+
+Every model path, image, hardware name, and measurement must be explicitly
+synthetic.
+
+- [ ] **Step 4: Create source-linked v0.5.16 rules**
+
+Encode at least:
+
+- `--fp4-gemm-backend cutlass` to `auto`, source SGLang PR #30448;
+- `--enable-deepep-waterfill` to `--enable-waterfill`, source PR #27350;
+- `--optimistic-prefill-retries` to
+  `--optimistic-prefill-attempts`, source PR #30951;
+- UnifiedRadixTree default behavior for SWA/Mamba/DSA, source PR #30468;
+- chunked input-logprob default behavior, source PR #31498;
+- `sglang.kernels` import relocation, sources PRs #30044 and #31582;
+- temperature-zero DP-attention/breakable-graph known issue, source PR #31125;
+- diffusion rollout msgpack transport change, source PR #31565.
+
+Use only direct GitHub release or PR URLs. The exact fixture profiles should
+match only the intended subset.
+
+- [ ] **Step 5: Generate the committed fixture report**
+
+```bash
+python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
+  --profiles skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json \
+  --rules skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json \
+  --output-markdown skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md \
+  --output-json /tmp/sglang-v0516-upgrade-fixture-result.json
+```
+
+Expected: `plain-tp=GO`, `legacy-fp4-pd=CONDITIONAL_GO`,
+`deterministic-dp-graph=NO_GO`, overall `NO_GO`.
+
+- [ ] **Step 6: Run fixture and analyzer tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit the demonstration**
+
+```bash
+git add tests/test_upgrade_readiness_auditor.py \
+  skills/sglang-upgrade-readiness-auditor/examples
+git commit -m "test: demonstrate SGLang v0.5.16 upgrade audit"
+```
+
+### Task 6: Write the Skill and References
+
+**Files:**
+- Create: `skills/sglang-upgrade-readiness-auditor/SKILL.md`
+- Create: `skills/sglang-upgrade-readiness-auditor/references/evidence-and-rule-authoring.md`
+- Create: `skills/sglang-upgrade-readiness-auditor/references/profile-and-rule-schema.md`
+- Modify: `tests/test_upgrade_readiness_auditor.py`
+
+- [ ] **Step 1: Add failing documentation contract tests**
+
+```python
+class SkillDocumentationTest(unittest.TestCase):
+    def test_skill_has_read_only_and_verdict_contract(self) -> None:
+        skill = (
+            ROOT / "skills" / "sglang-upgrade-readiness-auditor" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        for required in [
+            "name: sglang-upgrade-readiness-auditor",
+            "read-only",
+            "immutable",
+            "GO",
+            "CONDITIONAL_GO",
+            "NO_GO",
+            "canary",
+            "rollback",
+            "never execute",
+            "SYNTHETIC FIXTURE",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_references_define_source_priority_and_safe_argv(self) -> None:
+        root = ROOT / "skills" / "sglang-upgrade-readiness-auditor"
+        evidence = (root / "references" / "evidence-and-rule-authoring.md").read_text(encoding="utf-8")
+        schema = (root / "references" / "profile-and-rule-schema.md").read_text(encoding="utf-8")
+        self.assertIn("Release", evidence)
+        self.assertIn("compare", evidence)
+        self.assertIn("argv arrays", schema)
+        self.assertIn("rename_flag", schema)
+```
+
+- [ ] **Step 2: Run tests and verify missing docs**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor.SkillDocumentationTest -v
+```
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `SKILL.md`**
+
+Use:
+
+```yaml
+---
+name: sglang-upgrade-readiness-auditor
+description: "Audit an SGLang deployment before changing versions by matching release, CLI, dependency, default-behavior, known-issue, and internal-import changes to actual launch profiles. Use for GO/CONDITIONAL_GO/NO_GO decisions, proposed command migrations, canaries, and rollback plans."
+---
+```
+
+The workflow must require immutable version endpoints and actual argv/profile
+inventory, prioritize official sources, author evidence-linked rules, run the
+analyzer, review proposed commands without executing them, run separately
+authorized canaries, update canary results, and issue a scoped verdict. State
+that audit mode is read-only and never executes rendered commands, edits
+production manifests, pulls images, or restarts services.
+
+- [ ] **Step 4: Write the two references**
+
+`evidence-and-rule-authoring.md` must cover release/compare/CLI/dependency/source
+priority; rule classification; known-issue scope; confidence and unknowns;
+version-crossing semantics; direct sources; canary derivation; and
+future-release refresh.
+
+`profile-and-rule-schema.md` must document every profile, audit, rule,
+predicate, transformation, result, and verdict field; argv arrays; flag arity;
+conflict behavior; fixture labels; and examples that never use shell
+evaluation.
+
+- [ ] **Step 5: Run documentation and analyzer tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit the operational skill**
+
+```bash
+git add skills/sglang-upgrade-readiness-auditor/SKILL.md \
+  skills/sglang-upgrade-readiness-auditor/references \
+  tests/test_upgrade_readiness_auditor.py
+git commit -m "docs: add SGLang upgrade readiness workflow"
+```
+
+### Task 7: Register and Validate the Skill
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `tests/test_repository_metadata.py`
+- Modify only validation-exposed defects elsewhere.
+
+- [ ] **Step 1: Add failing metadata assertions**
+
+Change `core_skills-11` to `core_skills-12` and add:
+
+```python
+def test_upgrade_readiness_auditor_is_registered() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    assert "sglang-upgrade-readiness-auditor" in readme
+    assert "upgrade" in plugin["description"].lower()
+    assert "upgrade" in marketplace["plugins"][0]["description"].lower()
+```
+
+- [ ] **Step 2: Run metadata tests and verify failure**
+
+```bash
+python3 -m unittest tests.test_repository_metadata -v
+```
+
+Expected: failure until registration is added.
+
+- [ ] **Step 3: Register the skill**
+
+Add the skill to the README headline, core table, install commands, invocation
+examples, and repository map. Change the badge to `core_skills-12` and the
+Claude plugin installed total from 12 to 13. Mention upgrade readiness in both
+plugin descriptions without changing the published plugin version.
+
+- [ ] **Step 4: Regenerate and compare the fixture report**
+
+```bash
+python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
+  --profiles skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json \
+  --rules skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json \
+  --output-markdown /tmp/upgrade-readiness-fixture-report.md \
+  --output-json /tmp/upgrade-readiness-fixture-result.json
+diff -u skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md \
+  /tmp/upgrade-readiness-fixture-report.md
+```
+
+Expected: no diff.
+
+- [ ] **Step 5: Run focused and repository tests**
+
+```bash
+python3 -m unittest tests.test_upgrade_readiness_auditor -v
+python3 -m unittest tests.test_repository_metadata -v
+python3 -m unittest discover -s tests -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run syntax and repository checks**
+
+```bash
+python3 -m py_compile \
+  skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
+  tests/test_upgrade_readiness_auditor.py
+SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 7: Review scope and safety**
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  skills/sglang-upgrade-readiness-auditor README.md \
+  .claude-plugin tests/test_upgrade_readiness_auditor.py \
+  tests/test_repository_metadata.py
+```
+
+Expected: only planned files appear; fixture deployments are synthetic; every
+rule has a direct source; the analyzer never executes commands; no credentials
+or private deployment identifiers appear.
+
+- [ ] **Step 8: Commit registration and validation fixes**
+
+```bash
+git add README.md .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+  tests/test_repository_metadata.py
+git commit -m "docs: register SGLang upgrade readiness auditor"
+```
+
+If validation changed another in-scope file, stage it explicitly in a separate
+`test: validate SGLang upgrade readiness auditor` commit.
+
+- [ ] **Step 9: Push and open the draft PR**
+
+```bash
+git push -u origin codex/add-sglang-upgrade-readiness-auditor
+gh pr create --draft --base main \
+  --head codex/add-sglang-upgrade-readiness-auditor \
+  --title "Add SGLang upgrade readiness auditor skill" \
+  --body-file /tmp/sglang-upgrade-readiness-auditor-pr.md
+```
+
+The PR body must include the read-only safety boundary, v0.5.15-to-v0.5.16
+fixture result, exact demo and test commands, source-link policy, synthetic
+deployment disclaimer, and non-goals.

--- a/docs/superpowers/specs/2026-07-28-sglang-upgrade-readiness-auditor-design.md
+++ b/docs/superpowers/specs/2026-07-28-sglang-upgrade-readiness-auditor-design.md
@@ -1,0 +1,302 @@
+# SGLang Upgrade Readiness Auditor Design
+
+## Purpose
+
+Add a version-aware skill that determines whether an existing SGLang deployment
+can safely move from one revision or image to another. The skill turns upstream
+release notes, compare diffs, CLI evidence, dependency changes, known issues,
+and the deployment's actual launch surface into a concrete migration report.
+
+The motivating example is SGLang v0.5.15 to v0.5.16, which includes removed
+quantization paths, renamed flags without deprecated aliases, default behavior
+changes, dependency updates, and configuration-specific known issues. The skill
+must generalize to future version pairs and must not hard-code a claim that the
+latest release is safe for every deployment.
+
+## Success Criteria
+
+The pull request is complete when:
+
+1. `sglang-upgrade-readiness-auditor` has a clear trigger distinct from
+   production incident replay and performance optimization.
+2. The workflow records immutable current and target revisions, deployment
+   commands, model/quantization/parallelism features, hardware, and integrations
+   before making a decision.
+3. Evidence is classified as blocker, required change, behavior change, known
+   risk, dependency change, or informational.
+4. A deterministic analyzer matches structured upgrade rules against one or
+   more deployment profiles and emits `GO`, `CONDITIONAL_GO`, or `NO_GO`.
+5. Suggested command rewrites are explicit, reviewable, shell-safe
+   argument-level transformations; the skill never silently edits production
+   configuration.
+6. The final report includes matched evidence, migrated-command suggestions,
+   canary tests, rollback triggers, and unresolved unknowns.
+7. Unit tests and a v0.5.15-to-v0.5.16 fixture demo run without installing
+   either SGLang version.
+8. The focused branch is pushed and opened as its own draft pull request
+   against `main`.
+
+## Approaches Considered
+
+### 1. Release-note summarizer
+
+Summarize the releases between two tags and let the user decide what applies.
+This is broadly useful but does not inspect the actual deployment, rewrite
+commands, or produce a testable readiness verdict.
+
+### 2. Evidence workflow plus deterministic deployment matcher
+
+Use `SKILL.md` to collect authoritative version evidence and encode
+deployment-relevant findings in a small structured rule file. Use a
+standard-library analyzer to match those rules against deployment profiles,
+apply safe token-level rewrites, and generate a report and canary plan.
+
+This is the chosen approach. It separates human/agent interpretation of upstream
+changes from deterministic application to concrete deployments.
+
+### 3. Automated in-place upgrader
+
+Change images, launch scripts, manifests, or Helm values and run a rollout.
+That crosses an operational safety boundary, assumes one deployment system, and
+would make the skill destructive. The auditor will instead produce proposed
+changes and validation gates that another authorized workflow can apply.
+
+## User Contract
+
+Required inputs:
+
+- current SGLang version, commit, or image;
+- target SGLang version, commit, or image;
+- at least one exact launch command or structured deployment profile;
+- model identifier and quantization;
+- GPU type/count and TP/PP/DP/EP/CP/PD topology.
+
+Optional inputs:
+
+- environment variables;
+- Docker, Kubernetes, Slurm, or systemd configuration paths;
+- internal Python imports or extension packages;
+- frontend, router, KV-transfer, observability, RL, or diffusion integrations;
+- required correctness, determinism, availability, and performance guarantees.
+
+When the current version, target version, or deployment command is unknown, the
+skill reports an incomplete audit rather than assuming defaults.
+
+## Architecture and Component Boundaries
+
+### `SKILL.md`
+
+Owns the evidence and decision workflow:
+
+1. inventory every in-scope deployment profile and freeze current behavior;
+2. resolve current and target immutable revisions;
+3. collect official releases, compare links/diffs, CLI help, dependency
+   manifests, migration notes, known issues, and relevant source changes;
+4. convert applicable findings into structured rules with direct evidence
+   links and confidence;
+5. run the deterministic analyzer against each deployment profile;
+6. review suggested command transformations;
+7. construct correctness, determinism, API, performance, long-context, and
+   failure-recovery canaries from matched risks;
+8. issue a readiness verdict with unresolved unknowns and rollback triggers.
+
+The skill is read-only by default. It does not pull images, modify manifests,
+restart servers, or deploy the target release unless the user separately
+authorizes those actions.
+
+### Evidence reference
+
+A concise reference defines source priority:
+
+1. target release and official upgrade notes;
+2. exact tag-to-tag compare and merged PR diffs;
+3. CLI help and dependency metadata from both immutable revisions;
+4. official docs/cookbooks scoped to those revisions;
+5. issues only for explicitly labeled known-risk context.
+
+It explains how to distinguish removed interfaces, renamed interfaces, default
+changes, dependency constraints, known issues, fixes, and unrelated changes.
+Release-note absence is not proof of compatibility.
+
+### Deployment profile
+
+The analyzer consumes a JSON profile containing:
+
+- stable profile ID and full argv token list;
+- relevant environment variables;
+- model, quantization, hardware, topology, and enabled features;
+- optional internal imports and integration tags;
+- required guarantees such as temperature-zero determinism.
+
+Commands are represented as argv arrays, not evaluated shell strings. Rendered
+commands use shell quoting only for display.
+
+### Upgrade rule schema
+
+Each manually evidenced rule contains:
+
+- stable rule ID, category, severity, title, and target version range;
+- direct upstream source URL and evidence summary;
+- match conditions over flags, environment variables, imports, model traits,
+  topology, hardware, or integration tags;
+- optional exact transformations such as rename flag, remove flag, replace
+  value, or replace import prefix;
+- required canary checks;
+- notes and unresolved limitations.
+
+Rules without a safe mechanical transformation still produce findings. A
+rewrite is never invented merely to eliminate a warning.
+
+### Deterministic analyzer
+
+The Python CLI:
+
+1. validates profile and rule schemas;
+2. matches target-applicable rules to each profile;
+3. detects conflicting transformations;
+4. produces proposed argv after safe token-level rewrites;
+5. derives a per-profile and overall verdict;
+6. emits Markdown and JSON reports;
+7. lists unmatched high-risk features as audit coverage gaps.
+
+Verdict rules are explicit:
+
+- `NO_GO`: an unresolved blocker or conflicting/unsafe required migration;
+- `CONDITIONAL_GO`: required changes, known risks, or evidence gaps remain but
+  no unresolved blocker is present;
+- `GO`: no blockers or required changes remain and all required canaries pass.
+
+Because the offline analyzer cannot run target-version canaries by itself, its
+pre-canary result normally cannot exceed `CONDITIONAL_GO`. `GO` requires
+recorded canary evidence.
+
+## Data Flow
+
+```text
+current deployment profiles + current/target revisions
+                              |
+                              v
+       releases + diffs + CLI + dependencies + known issues
+                              |
+                              v
+             evidence-backed structured upgrade rules
+                              |
+                              v
+       rule matching + safe argv rewrite + conflict detection
+                              |
+                              v
+       findings + proposed commands + canary/rollback matrix
+                              |
+                              v
+                 GO / CONDITIONAL_GO / NO_GO
+```
+
+## Safety and Integrity Rules
+
+- Never execute a rendered launch command while auditing it.
+- Never source user shell files or evaluate command substitutions.
+- Never edit deployment files unless separately authorized after the report.
+- Resolve both endpoints to immutable versions or commits.
+- Attach every rule to a direct source and retain uncertainty when evidence is
+  incomplete.
+- Do not extrapolate a known issue beyond its documented configuration without
+  labeling the inference.
+- Default changes receive behavior canaries even when no flag is removed.
+- Internal import scanning is opt-in and limited to user-scoped paths.
+- Logs, tokens, registry credentials, and private image names are sanitized from
+  committed examples and reports.
+
+## Demonstration
+
+The pull request includes a fixture audit for SGLang v0.5.15 to v0.5.16. The
+fixture contains multiple deployment profiles so the report can demonstrate:
+
+- removal of an unsupported quantization or GEMM path;
+- exact flag renames without deprecated aliases;
+- a default behavior change that requires a regression canary;
+- a configuration-specific determinism risk;
+- a profile unaffected by a model-specific change.
+
+The demo report shows:
+
+1. matched and non-matched rules per deployment;
+2. original and proposed argv;
+3. blockers versus conditional risks;
+4. required canaries and rollback triggers;
+5. an overall pre-canary verdict.
+
+All deployment inputs are synthetic and clearly labeled. Release facts cite
+their upstream sources; no fixture is represented as a production deployment.
+
+## Error Handling
+
+- Reject malformed profiles, duplicate IDs, missing versions, invalid rule
+  ranges, unknown transformations, ambiguous flag arity, and conflicting
+  rewrites.
+- Preserve a finding and withhold a rewrite when the command structure is
+  ambiguous.
+- Return non-zero for invalid evidence or analyzer failure.
+- Return a valid `NO_GO` or `CONDITIONAL_GO` report with zero status when the
+  audit completed successfully and the verdict itself is unfavorable.
+- Surface unmatched deployment features as coverage gaps rather than silently
+  declaring compatibility.
+
+## Testing and Validation
+
+Validation includes:
+
+1. unit tests for matching, version applicability, rewrites, conflicts,
+   verdicts, quoting, unknowns, and multi-profile aggregation;
+2. a stable fixture-demo report for v0.5.15 to v0.5.16;
+3. Python compilation and CLI help checks;
+4. direct-link verification for every committed example rule;
+5. the repository's skill validator and metadata tests;
+6. Markdown and link checks used by the repository;
+7. a staged-diff review for unsafe execution guidance, unsupported upgrade
+   claims, secrets, and overlap with incident-triage behavior.
+
+The fixture proves the auditor's matching and reporting behavior, not that an
+actual deployment passed its canaries.
+
+## Planned Repository Layout
+
+```text
+skills/sglang-upgrade-readiness-auditor/
+├── SKILL.md
+├── references/
+│   ├── evidence-and-rule-authoring.md
+│   └── profile-and-rule-schema.md
+├── scripts/
+│   └── audit_upgrade.py
+├── examples/
+│   ├── v0.5.15-to-v0.5.16-profiles.json
+│   ├── v0.5.15-to-v0.5.16-rules.json
+│   └── fixture-report.md
+└── tests/
+    └── test_audit_upgrade.py
+```
+
+The root README, plugin manifest, marketplace metadata, and repository tests
+will be updated only as required to register the new skill.
+
+## Non-Goals
+
+- Automatically deploying, restarting, or rolling back SGLang.
+- Maintaining a permanent complete database of every historical release.
+- Guaranteeing compatibility from release notes alone.
+- Replacing production canaries or incident replay.
+- Modifying SGLang source to restore a removed backend.
+- Reading unrelated private repositories or deployment credentials.
+
+## Commit and Pull Request Strategy
+
+Use focused commits for:
+
+1. this approved design and the implementation plan;
+2. the skill workflow, references, schemas, and analyzer;
+3. tests, v0.5.16 fixture demo, registration, and validation-driven
+   corrections.
+
+Push `codex/add-sglang-upgrade-readiness-auditor` and open a draft pull request
+against `main`. The pull request will include the exact demo command, sample
+output, validation commands, cited upstream evidence, and safety limitations.

--- a/skills/sglang-upgrade-readiness-auditor/SKILL.md
+++ b/skills/sglang-upgrade-readiness-auditor/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: sglang-upgrade-readiness-auditor
+description: "Audit an SGLang deployment before changing releases, commits, or images by matching official release, CLI, dependency, default-behavior, known-issue, API, and internal-import changes to actual launch profiles. Use for GO/CONDITIONAL_GO/NO_GO decisions, proposed argv or import migrations, upgrade canaries, rollback plans, and version-specific compatibility reviews; especially when commands use quantization, speculative decoding, PD/DP/EP/CP, HiCache, custom kernels, diffusion rollout, or internal SGLang imports."
+---
+
+# SGLang Upgrade Readiness Auditor
+
+## Objective
+
+Turn a version diff into a deployment-specific decision. Inventory real launch
+profiles, attach every finding to authoritative evidence, propose reviewable
+argv/import changes, require relevant canaries, and issue `GO`,
+`CONDITIONAL_GO`, or `NO_GO`.
+
+Keep audit mode **read-only**. Never execute rendered commands, source shell
+files, pull images, edit manifests, restart servers, or perform a rollout.
+Canary execution and deployment changes require separate authorization after
+the report.
+
+## Required Inventory
+
+Resolve before deciding:
+
+| Field | Required detail |
+| --- | --- |
+| Current | Immutable tag/commit or image digest |
+| Target | Immutable tag/commit or image digest |
+| Launch surface | Exact argv arrays and relevant environment variables |
+| Model | ID/revision, architecture family, quantization |
+| Hardware | GPU model/count and topology |
+| Parallelism | TP, PP, DP, EP, CP, PD/disaggregation |
+| Features | Cache, graph, logprob, speculative, LoRA, router, rollout, custom extension paths |
+| Guarantees | Correctness, determinism, API, availability, and performance requirements |
+| Integrations | Routers, KV transfer, observability, RL/diffusion clients, private extensions |
+
+If either version or the actual launch surface is unknown, return an incomplete
+audit. Do not replace missing deployment facts with target-release defaults.
+
+## Workflow
+
+### 1. Freeze current behavior
+
+Record:
+
+- current command/environment and immutable revisions;
+- a healthy current-version startup log;
+- correctness and API smoke outputs;
+- determinism evidence when required;
+- representative performance and memory baseline;
+- current rollback command/image;
+- every in-scope deployment profile.
+
+Represent commands as argv arrays. Do not evaluate shell strings or command
+substitutions.
+
+### 2. Resolve the version interval
+
+Resolve mutable branch/image names to immutable commits or digests. Confirm the
+target is newer than the current version. Record exact release and compare URLs.
+
+Read [evidence-and-rule-authoring.md](references/evidence-and-rule-authoring.md).
+Inspect official Releases, tag-to-tag compare/diffs, CLI help at both revisions,
+dependency metadata, source, cookbooks, and known issues. Release-note absence
+is not proof of compatibility.
+
+### 3. Classify changes
+
+Classify only deployment-relevant evidence:
+
+- removed or renamed interface;
+- required dependency/backend change;
+- default behavior change;
+- API/transport/schema change;
+- internal import relocation;
+- known issue or reverted fix;
+- informational change.
+
+Scope model-, hardware-, backend-, and topology-specific evidence precisely.
+Do not generalize one configuration's issue to all deployments.
+
+### 4. Author profiles and rules
+
+Read [profile-and-rule-schema.md](references/profile-and-rule-schema.md). Write:
+
+1. one profile document containing the version interval and all deployment
+   profiles;
+2. one evidence-backed rule document for the interval.
+
+Attach a direct source URL, applicability mode/version, predicates, severity,
+canaries, and rollback to every rule. Add a transformation only when the source
+supports a safe exact rewrite.
+
+### 5. Run the auditor
+
+```bash
+python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
+  --profiles /path/to/deployment-profiles.json \
+  --rules /path/to/upgrade-rules.json \
+  --output-markdown /path/to/upgrade-readiness.md \
+  --output-json /path/to/upgrade-readiness.json
+```
+
+The analyzer validates the inputs, applies version and profile predicates,
+detects conflicting transformations, proposes argv/import changes, derives
+canaries, and aggregates verdicts. It never executes input or output commands.
+
+### 6. Review every proposed change
+
+For each matched profile:
+
+- compare original and proposed argv token by token;
+- inspect import-prefix changes at symbol level;
+- reject a rewrite if flag arity or module mapping is ambiguous;
+- keep findings without transformations as manual actions;
+- resolve coverage gaps before calling the audit complete.
+
+Treat proposals as patches for review, not as deployed configuration.
+
+### 7. Run separately authorized canaries
+
+After approval to test the target version, run only in an isolated canary
+environment. Derive tests from matched rules plus the base contract:
+
+- startup and worker health;
+- model-output and logprob parity;
+- temperature-zero determinism where required;
+- API/streaming/tool/reasoning schemas;
+- long-context and prefix-cache behavior;
+- TP/DP/EP/CP/PD failure, abort, and retry paths;
+- custom import/extension smoke tests;
+- representative TTFT, TPOT, throughput, and peak memory.
+
+Write `pass`, `fail`, or `not_run` results back to the profile and rerun the
+auditor. Do not mark an unexecuted canary as passing.
+
+### 8. Issue the decision
+
+Use these meanings:
+
+| Verdict | Meaning |
+| --- | --- |
+| `GO` | No blocking/conditional finding remains and all required canaries pass |
+| `CONDITIONAL_GO` | Required changes, behavior/risk findings, or incomplete canaries remain |
+| `NO_GO` | An unresolved blocker or unsafe/conflicting transformation remains |
+
+Report per-profile and overall verdicts, findings with sources, proposed
+commands/imports, coverage gaps, canaries, and rollback triggers.
+
+## Handoffs
+
+- Use `sglang-prod-incident-triage` when the current or target canary has already
+  become an incident requiring replay-first diagnosis.
+- Use `llm-serving-auto-benchmark` when the remaining question is a fair
+  performance search rather than compatibility.
+- Use `sglang-sota-humanize-loop` only when the authorized outcome requires an
+  SGLang source change.
+
+Preserve this audit's version evidence and profile artifacts during handoff.
+
+## Safety Rules
+
+- Keep audit mode read-only.
+- Never execute a rendered command.
+- Never source or interpolate profile input.
+- Never modify production config or deployment state without new authority.
+- Never declare compatibility from a release title alone.
+- Never drop an unmatched high-risk feature silently; report it as coverage.
+- Never propose a rewrite when flag arity, value semantics, or import mapping is
+  ambiguous.
+- Sanitize registry credentials, tokens, private image names, hosts, and paths
+  from committed examples.
+
+## Demonstration
+
+Run the committed v0.5.15-to-v0.5.16 example:
+
+```bash
+python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
+  --profiles skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json \
+  --rules skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json \
+  --output-markdown /tmp/v0516-upgrade-fixture.md \
+  --output-json /tmp/v0516-upgrade-fixture.json
+```
+
+The report starts with **SYNTHETIC FIXTURE**. It demonstrates one `GO`, one
+`CONDITIONAL_GO` with argv/import rewrites, and one `NO_GO` determinism blocker.
+It is not evidence that a real deployment passed v0.5.16 canaries.
+
+## Resources
+
+- [evidence-and-rule-authoring.md](references/evidence-and-rule-authoring.md):
+  read for every new version interval.
+- [profile-and-rule-schema.md](references/profile-and-rule-schema.md): read
+  before creating analyzer input or integrating deployment inventory.
+- `scripts/audit_upgrade.py`: deterministic matching, rewrite, verdict, and
+  reporting engine.
+- `examples/fixture-report.md`: expected demonstration output.

--- a/skills/sglang-upgrade-readiness-auditor/agents/openai.yaml
+++ b/skills/sglang-upgrade-readiness-auditor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang Upgrade Readiness Auditor"
+  short_description: "Audit SGLang upgrades before rollout"
+  default_prompt: "Use $sglang-upgrade-readiness-auditor to audit this SGLang version upgrade and produce a safe migration and canary plan."

--- a/skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md
+++ b/skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md
@@ -1,0 +1,114 @@
+# SGLang Upgrade Readiness Audit
+
+> **SYNTHETIC FIXTURE:** Deployment profiles and canary results are invented for analyzer demonstration.
+
+- Current: `v0.5.15`
+- Target: `v0.5.16`
+- Overall verdict: **NO_GO**
+- Safety: read-only analysis; no command below was executed.
+
+## Profile Verdicts
+
+| Profile | Verdict | Findings | Proposed changes | Missing/failing canaries | Coverage gaps |
+| --- | --- | ---: | --- | --- | --- |
+| `deterministic-dp-graph` | **NO_GO** | 1 | no | temperature_zero_determinism | none |
+| `legacy-fp4-pd` | **CONDITIONAL_GO** | 6 | yes | import_smoke, input_logprob_parity, long_context, pd_retry_abort, peak_memory, prefix_cache | pd_disaggregation |
+| `plain-tp` | **GO** | 0 | no | none | none |
+
+## Findings
+
+### `deterministic-dp-graph`
+
+- **BLOCKER** `dp-breakable-graph-temperature-zero-nondeterminism` — Temperature-zero nondeterminism in an affected DP graph path. The v0.5.16 known issue says identical temperature-zero requests can diverge with DP attention and breakable prefill CUDA Graph. ([source](https://github.com/sgl-project/sglang/pull/31125))
+
+### `legacy-fp4-pd`
+
+- **REQUIRED** `fp4-cutlass-backend-removed` — CUTLASS FP4 backend value removed. The in-tree NVFP4 JIT path and cutlass value were removed; v0.5.16 release guidance says to use auto. ([source](https://github.com/sgl-project/sglang/pull/30448))
+- **REQUIRED** `deepep-waterfill-flag-renamed` — Waterfill flag renamed without alias. --enable-deepep-waterfill became --enable-waterfill and the old spelling is rejected. ([source](https://github.com/sgl-project/sglang/pull/27350))
+- **REQUIRED** `optimistic-prefill-attempts-rename` — Optimistic prefill retries flag renamed. --optimistic-prefill-retries became --optimistic-prefill-attempts with no deprecated alias. ([source](https://github.com/sgl-project/sglang/pull/30951))
+- **BEHAVIOR** `unified-radix-tree-default` — UnifiedRadixTree becomes the DSA/Mamba/SWA default. The cache implementation changes by default for DSA, Mamba, and SWA architectures. ([source](https://github.com/sgl-project/sglang/pull/30468))
+- **BEHAVIOR** `chunked-input-logprob-default` — Chunked input-logprob processing enabled by default. Input-logprob requests use chunked processing by default to cap peak memory. ([source](https://github.com/sgl-project/sglang/pull/31498))
+- **REQUIRED** `kernel-namespace-relocation` — Internal kernels move to sglang.kernels. The release relocates internal kernel imports into the sglang.kernels namespace. ([source](https://github.com/sgl-project/sglang/releases/tag/v0.5.16))
+
+## Proposed Commands
+
+### `deterministic-dp-graph`
+
+Original argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dsv4-fp4 --tp 8 --dp 8 --enable-dp-attention --enable-piecewise-cuda-graph
+```
+
+Proposed argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dsv4-fp4 --tp 8 --dp 8 --enable-dp-attention --enable-piecewise-cuda-graph
+```
+
+### `legacy-fp4-pd`
+
+Original argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dsa-moe-model --tp 8 --fp4-gemm-backend cutlass --enable-deepep-waterfill --optimistic-prefill-retries 3
+```
+
+Proposed argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dsa-moe-model --tp 8 --fp4-gemm-backend auto --enable-waterfill --optimistic-prefill-attempts 3
+```
+
+Proposed imports:
+
+```text
+sglang.kernels.fast_op
+torch
+```
+
+### `plain-tp`
+
+Original argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dense-model --tp 8
+```
+
+Proposed argv:
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/dense-model --tp 8
+```
+
+## Canaries and Rollback
+
+### `deterministic-dp-graph`
+
+- Required canaries: correctness, performance, server_health, temperature_zero_determinism
+- Missing/failing: temperature_zero_determinism
+- Rollback: Do not roll out this combination; disable the affected graph path or restore the previous release.
+
+### `legacy-fp4-pd`
+
+- Required canaries: correctness, import_smoke, input_logprob_parity, long_context, pd_retry_abort, peak_memory, performance, prefix_cache, server_health
+- Missing/failing: import_smoke, input_logprob_parity, long_context, pd_retry_abort, peak_memory, prefix_cache
+- Rollback: Restore the old extension and image if the exact relocated wrapper cannot be imported or validated.
+- Rollback: Restore the prior image and old flag if waterfill startup or throughput validation fails.
+- Rollback: Restore the prior release if logprob parity or long-context behavior changes unexpectedly.
+- Rollback: Restore the v0.5.15 image if the FlashInfer-selected auto backend fails correctness or performance canaries.
+- Rollback: Restore v0.5.15 if PD retry, abort, or parked-request canaries fail.
+- Rollback: Return to the prior release if cache-hit, long-context, or output-parity canaries regress.
+
+### `plain-tp`
+
+- Required canaries: correctness, performance, server_health
+- Missing/failing: none
+- Rollback: restore the recorded current version and argv.
+
+## Interpretation
+
+- `GO`: no blocking or conditional finding remains and all required canaries are recorded as passing.
+- `CONDITIONAL_GO`: apply/review proposed changes or complete required canaries before rollout.
+- `NO_GO`: resolve the blocker or choose a different target/configuration.
+- Review every proposed argv. This auditor never executes it.

--- a/skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json
+++ b/skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 1,
+  "fixture": true,
+  "audit": {
+    "current_version": "v0.5.15",
+    "target_version": "v0.5.16",
+    "required_canaries": [
+      "server_health",
+      "correctness",
+      "performance"
+    ]
+  },
+  "profiles": [
+    {
+      "id": "plain-tp",
+      "argv": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/dense-model",
+        "--tp",
+        "8"
+      ],
+      "env": {},
+      "model_family": "dense",
+      "quantization": "fp8",
+      "hardware": "synthetic-b200",
+      "topology": {
+        "tp": 8,
+        "pp": 1,
+        "dp": 1,
+        "ep": 1,
+        "cp": 1
+      },
+      "features": [],
+      "guarantees": [],
+      "integrations": [],
+      "imports": [],
+      "canary_results": {
+        "server_health": "pass",
+        "correctness": "pass",
+        "performance": "pass"
+      }
+    },
+    {
+      "id": "legacy-fp4-pd",
+      "argv": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/dsa-moe-model",
+        "--tp",
+        "8",
+        "--fp4-gemm-backend",
+        "cutlass",
+        "--enable-deepep-waterfill",
+        "--optimistic-prefill-retries",
+        "3"
+      ],
+      "env": {},
+      "model_family": "dsa-moe",
+      "quantization": "nvfp4",
+      "hardware": "synthetic-b200",
+      "topology": {
+        "tp": 8,
+        "pp": 1,
+        "dp": 8,
+        "ep": 8,
+        "cp": 1
+      },
+      "features": [
+        "dsa_model",
+        "input_logprobs",
+        "pd_disaggregation"
+      ],
+      "guarantees": [
+        "api_compatibility"
+      ],
+      "integrations": [],
+      "imports": [
+        "sglang.jit_kernel.fast_op",
+        "torch"
+      ],
+      "canary_results": {
+        "server_health": "pass",
+        "correctness": "pass",
+        "performance": "pass",
+        "import_smoke": "not_run",
+        "long_context": "not_run",
+        "pd_retry_abort": "not_run"
+      }
+    },
+    {
+      "id": "deterministic-dp-graph",
+      "argv": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/dsv4-fp4",
+        "--tp",
+        "8",
+        "--dp",
+        "8",
+        "--enable-dp-attention",
+        "--enable-piecewise-cuda-graph"
+      ],
+      "env": {},
+      "model_family": "deepseek-v4",
+      "quantization": "nvfp4",
+      "hardware": "synthetic-b300",
+      "topology": {
+        "tp": 8,
+        "pp": 1,
+        "dp": 8,
+        "ep": 8,
+        "cp": 1
+      },
+      "features": [
+        "dp_attention",
+        "breakable_prefill_cuda_graph"
+      ],
+      "guarantees": [
+        "temperature_zero_determinism"
+      ],
+      "integrations": [],
+      "imports": [],
+      "canary_results": {
+        "server_health": "pass",
+        "correctness": "pass",
+        "performance": "pass",
+        "temperature_zero_determinism": "fail"
+      }
+    }
+  ]
+}

--- a/skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json
+++ b/skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json
@@ -1,0 +1,257 @@
+{
+  "schema_version": 1,
+  "rules": [
+    {
+      "id": "fp4-cutlass-backend-removed",
+      "category": "removed_interface",
+      "severity": "required",
+      "title": "CUTLASS FP4 backend value removed",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/30448",
+      "summary": "The in-tree NVFP4 JIT path and cutlass value were removed; v0.5.16 release guidance says to use auto.",
+      "match": {
+        "all": [
+          {
+            "kind": "argv_value",
+            "name": "--fp4-gemm-backend",
+            "equals": "cutlass"
+          }
+        ]
+      },
+      "transforms": [
+        {
+          "kind": "replace_value",
+          "flag": "--fp4-gemm-backend",
+          "from": "cutlass",
+          "to": "auto"
+        }
+      ],
+      "canaries": [
+        "server_health",
+        "correctness",
+        "performance"
+      ],
+      "rollback": "Restore the v0.5.15 image if the FlashInfer-selected auto backend fails correctness or performance canaries."
+    },
+    {
+      "id": "deepep-waterfill-flag-renamed",
+      "category": "renamed_interface",
+      "severity": "required",
+      "title": "Waterfill flag renamed without alias",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/27350",
+      "summary": "--enable-deepep-waterfill became --enable-waterfill and the old spelling is rejected.",
+      "match": {
+        "all": [
+          {
+            "kind": "argv_flag",
+            "name": "--enable-deepep-waterfill"
+          }
+        ]
+      },
+      "transforms": [
+        {
+          "kind": "rename_flag",
+          "from": "--enable-deepep-waterfill",
+          "to": "--enable-waterfill"
+        }
+      ],
+      "canaries": [
+        "server_health",
+        "performance"
+      ],
+      "rollback": "Restore the prior image and old flag if waterfill startup or throughput validation fails."
+    },
+    {
+      "id": "optimistic-prefill-attempts-rename",
+      "category": "renamed_interface",
+      "severity": "required",
+      "title": "Optimistic prefill retries flag renamed",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/30951",
+      "summary": "--optimistic-prefill-retries became --optimistic-prefill-attempts with no deprecated alias.",
+      "match": {
+        "all": [
+          {
+            "kind": "argv_flag",
+            "name": "--optimistic-prefill-retries"
+          }
+        ]
+      },
+      "transforms": [
+        {
+          "kind": "rename_flag",
+          "from": "--optimistic-prefill-retries",
+          "to": "--optimistic-prefill-attempts"
+        }
+      ],
+      "canaries": [
+        "pd_retry_abort",
+        "server_health"
+      ],
+      "rollback": "Restore v0.5.15 if PD retry, abort, or parked-request canaries fail."
+    },
+    {
+      "id": "unified-radix-tree-default",
+      "category": "default_change",
+      "severity": "behavior",
+      "title": "UnifiedRadixTree becomes the DSA/Mamba/SWA default",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/30468",
+      "summary": "The cache implementation changes by default for DSA, Mamba, and SWA architectures.",
+      "match": {
+        "all": [
+          {
+            "kind": "feature",
+            "value": "dsa_model"
+          }
+        ]
+      },
+      "transforms": [],
+      "canaries": [
+        "long_context",
+        "correctness",
+        "prefix_cache"
+      ],
+      "rollback": "Return to the prior release if cache-hit, long-context, or output-parity canaries regress."
+    },
+    {
+      "id": "chunked-input-logprob-default",
+      "category": "default_change",
+      "severity": "behavior",
+      "title": "Chunked input-logprob processing enabled by default",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/31498",
+      "summary": "Input-logprob requests use chunked processing by default to cap peak memory.",
+      "match": {
+        "all": [
+          {
+            "kind": "feature",
+            "value": "input_logprobs"
+          }
+        ]
+      },
+      "transforms": [],
+      "canaries": [
+        "input_logprob_parity",
+        "long_context",
+        "peak_memory"
+      ],
+      "rollback": "Restore the prior release if logprob parity or long-context behavior changes unexpectedly."
+    },
+    {
+      "id": "kernel-namespace-relocation",
+      "category": "internal_import_change",
+      "severity": "required",
+      "title": "Internal kernels move to sglang.kernels",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/releases/tag/v0.5.16",
+      "summary": "The release relocates internal kernel imports into the sglang.kernels namespace.",
+      "match": {
+        "all": [
+          {
+            "kind": "import_prefix",
+            "value": "sglang.jit_kernel"
+          }
+        ]
+      },
+      "transforms": [
+        {
+          "kind": "replace_import_prefix",
+          "from": "sglang.jit_kernel",
+          "to": "sglang.kernels"
+        }
+      ],
+      "canaries": [
+        "import_smoke",
+        "correctness"
+      ],
+      "rollback": "Restore the old extension and image if the exact relocated wrapper cannot be imported or validated."
+    },
+    {
+      "id": "dp-breakable-graph-temperature-zero-nondeterminism",
+      "category": "known_issue",
+      "severity": "blocker",
+      "title": "Temperature-zero nondeterminism in an affected DP graph path",
+      "applies": {
+        "mode": "target",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/31125",
+      "summary": "The v0.5.16 known issue says identical temperature-zero requests can diverge with DP attention and breakable prefill CUDA Graph.",
+      "match": {
+        "all": [
+          {
+            "kind": "feature",
+            "value": "dp_attention"
+          },
+          {
+            "kind": "feature",
+            "value": "breakable_prefill_cuda_graph"
+          },
+          {
+            "kind": "guarantee",
+            "value": "temperature_zero_determinism"
+          }
+        ]
+      },
+      "transforms": [],
+      "canaries": [
+        "temperature_zero_determinism"
+      ],
+      "rollback": "Do not roll out this combination; disable the affected graph path or restore the previous release."
+    },
+    {
+      "id": "diffusion-rollout-msgpack-transport",
+      "category": "api_change",
+      "severity": "required",
+      "title": "Diffusion rollout transport changes to msgpack",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/31565",
+      "summary": "Post-training rollout responses switch from JSON/base64 tensors to application/msgpack raw bytes.",
+      "match": {
+        "all": [
+          {
+            "kind": "integration",
+            "value": "diffusion_post_training_rollout"
+          }
+        ]
+      },
+      "transforms": [],
+      "canaries": [
+        "rollout_transport_contract",
+        "tensor_round_trip"
+      ],
+      "rollback": "Upgrade client and server in lockstep or keep both sides on the prior transport."
+    }
+  ]
+}

--- a/skills/sglang-upgrade-readiness-auditor/references/evidence-and-rule-authoring.md
+++ b/skills/sglang-upgrade-readiness-auditor/references/evidence-and-rule-authoring.md
@@ -1,0 +1,182 @@
+# Upgrade Evidence and Rule Authoring
+
+## Contents
+
+- [Source priority](#source-priority)
+- [Build the change inventory](#build-the-change-inventory)
+- [Applicability modes](#applicability-modes)
+- [Classify severity](#classify-severity)
+- [Write safe matches and transforms](#write-safe-matches-and-transforms)
+- [Derive canaries and rollback](#derive-canaries-and-rollback)
+- [Unknowns and confidence](#unknowns-and-confidence)
+- [v0.5.16 example sources](#v0516-example-sources)
+
+## Source priority
+
+Use this order:
+
+1. Official GitHub Release and explicit upgrade notes for the target.
+2. Exact current-to-target GitHub compare and merged PR diffs.
+3. CLI help and dependency metadata from both immutable revisions.
+4. Source, tests, and official cookbooks at the target tag.
+5. Open issues or reverted PRs, labeled as known-risk context rather than
+   landed behavior.
+
+Record direct URLs. Prefer an implementation PR or exact tag path over a
+secondary summary. If a Release statement and source disagree, preserve the
+conflict and withhold a `GO`.
+
+Useful commands:
+
+```bash
+gh api repos/sgl-project/sglang/releases/tags/<target-tag>
+gh api repos/sgl-project/sglang/compare/<current-tag>...<target-tag>
+git diff <current-tag>...<target-tag> -- python/sglang/srt/server_args.py
+```
+
+Run CLI help from the exact installed images when available. Do not use a
+main-branch CLI to prove an older release.
+
+## Build the change inventory
+
+For every relevant change, record:
+
+```text
+title:
+category:
+introduced_in:
+fixed_in:
+source:
+affected flag/env/import/model/backend/topology/integration:
+behavior before:
+behavior after:
+mechanical rewrite possible:
+required canaries:
+rollback:
+confidence:
+```
+
+Search for:
+
+- deleted/renamed arguments and environment variables;
+- removed quantization, GEMM, attention, collective, or KV backends;
+- new defaults and default-off/default-on changes;
+- dependency pins and required extras;
+- Python namespace/internal import moves;
+- HTTP/gRPC/streaming/serialization schema changes;
+- model-, quantization-, hardware-, and topology-specific known issues;
+- reverted fixes still absent from the target;
+- router, PD, KV-transfer, diffusion, RL, LoRA, and observability integrations.
+
+Ignore unrelated models/features only after confirming no shared code or
+default surface affects the profile.
+
+## Applicability modes
+
+Use `crossing` for migrations that matter when the interval crosses their
+introduction:
+
+```text
+current < introduced_in <= target
+```
+
+Examples: a flag rename, removed backend, new default, or import relocation.
+
+Use `target` for a condition that remains present in every affected target until
+fixed:
+
+```text
+introduced_in <= target < fixed_in
+```
+
+Examples: a known issue or dependency incompatibility. Omit `fixed_in` while the
+condition remains unresolved.
+
+Do not use a `crossing` rule to represent a persistent known issue; an upgrade
+from one already-affected version to another would incorrectly hide it.
+
+## Classify severity
+
+| Severity | Use when | Typical verdict |
+| --- | --- | --- |
+| `blocker` | Required guarantee cannot be met or no safe migration is known | `NO_GO` |
+| `required` | Command/import/client must change before rollout | `CONDITIONAL_GO` |
+| `behavior` | Default/semantics changed and regression canaries are required | `CONDITIONAL_GO` |
+| `risk` | Target has a scoped known risk needing explicit acceptance/canary | `CONDITIONAL_GO` |
+| `dependency` | Package/driver/library lockstep is required | `CONDITIONAL_GO` |
+| `info` | Relevant but no action/canary remains | May remain `GO` |
+
+Severity is deployment-specific. A known nondeterminism is a blocker only when
+that profile requires determinism and matches the affected configuration.
+
+## Write safe matches and transforms
+
+Match the narrowest concrete profile surface. Prefer an `argv_value` predicate
+over a broad model-family predicate when a removed value is the real trigger.
+Combine predicates with `all` for configuration-specific issues.
+
+Add transforms only for exact, reviewable changes:
+
+- `rename_flag`;
+- `remove_flag` with explicit arity 0 or 1;
+- `replace_value` with an expected old value;
+- `replace_import_prefix` when the source establishes a prefix-preserving move.
+
+Do not encode:
+
+- arbitrary shell;
+- regex replacement over a command string;
+- image pulls, restarts, or deployment actions;
+- guessed flag arity;
+- a backend substitution whose correctness/performance behavior is unknown;
+- a Python import mapping that changes symbols or module layout unpredictably.
+
+Keep the finding without a transform when mechanical migration is unsafe.
+
+## Derive canaries and rollback
+
+Map the changed surface to a falsifiable target test:
+
+| Change | Minimum canary |
+| --- | --- |
+| Flag/backend | Startup, correctness, representative performance |
+| Default cache behavior | Long context, prefix hit, eviction, output parity |
+| Determinism issue | Repeated identical temperature-zero requests |
+| PD/queue behavior | Retry, abort, parked/inflight request recovery |
+| Logprob behavior | Token/logprob parity and peak memory |
+| API transport | Client/server schema and tensor round trip |
+| Internal import | Import smoke plus extension-level correctness |
+| Dependency | Import/version check plus affected execution path |
+
+Write a rollback that restores a known working image/configuration or disables
+the affected feature. Do not use “monitor closely” as a rollback.
+
+## Unknowns and confidence
+
+Treat these as audit gaps:
+
+- mutable current/target versions;
+- a launch profile reconstructed from memory;
+- undocumented private extension imports;
+- an unmatched high-risk feature;
+- a Release claim without source/CLI confirmation;
+- a target canary not run on the stated hardware/topology.
+
+Unknown does not mean safe. Keep the verdict conditional or blocked until the
+gap is resolved.
+
+## v0.5.16 example sources
+
+The committed fixture uses direct SGLang sources:
+
+- [v0.5.16 Release](https://github.com/sgl-project/sglang/releases/tag/v0.5.16)
+- [FP4 backend removal PR #30448](https://github.com/sgl-project/sglang/pull/30448)
+- [Waterfill rename PR #27350](https://github.com/sgl-project/sglang/pull/27350)
+- [Optimistic prefill rename PR #30951](https://github.com/sgl-project/sglang/pull/30951)
+- [UnifiedRadixTree default PR #30468](https://github.com/sgl-project/sglang/pull/30468)
+- [Chunked input-logprob default PR #31498](https://github.com/sgl-project/sglang/pull/31498)
+- [Determinism guard PR #31125](https://github.com/sgl-project/sglang/pull/31125)
+- [Diffusion msgpack transport PR #31565](https://github.com/sgl-project/sglang/pull/31565)
+
+These rules demonstrate authoring for one interval. Rebuild evidence for every
+new target instead of treating the fixture as a permanent release database.

--- a/skills/sglang-upgrade-readiness-auditor/references/profile-and-rule-schema.md
+++ b/skills/sglang-upgrade-readiness-auditor/references/profile-and-rule-schema.md
@@ -1,0 +1,216 @@
+# Profile, Rule, and Result Schema
+
+## Contents
+
+- [Profile document](#profile-document)
+- [Deployment profile](#deployment-profile)
+- [Rule document](#rule-document)
+- [Predicates](#predicates)
+- [Transformations](#transformations)
+- [Verdicts and result](#verdicts-and-result)
+- [Safety and fixtures](#safety-and-fixtures)
+
+## Profile document
+
+Use:
+
+```json
+{
+  "schema_version": 1,
+  "fixture": false,
+  "audit": {
+    "current_version": "v0.5.15",
+    "target_version": "v0.5.16",
+    "required_canaries": ["server_health", "correctness", "performance"]
+  },
+  "profiles": []
+}
+```
+
+Versions accept `vMAJOR.MINOR.PATCH` and `.postN`. The target must be newer.
+Use immutable tags/commits/images in the audit evidence even when the analyzer
+version label is a release.
+
+## Deployment profile
+
+```json
+{
+  "id": "production-pd",
+  "argv": ["python3", "-m", "sglang.launch_server", "--tp", "8"],
+  "env": {"SGLANG_EXAMPLE": "1"},
+  "model_family": "deepseek-v4",
+  "quantization": "nvfp4",
+  "hardware": "b200",
+  "topology": {"tp": 8, "pp": 1, "dp": 8, "ep": 8, "cp": 1},
+  "features": ["pd_disaggregation", "input_logprobs"],
+  "guarantees": ["temperature_zero_determinism"],
+  "integrations": ["custom_router"],
+  "imports": ["sglang.jit_kernel.fast_op"],
+  "canary_results": {
+    "server_health": "pass",
+    "correctness": "pass",
+    "performance": "not_run"
+  }
+}
+```
+
+Use argv arrays, never shell command strings. Values are parsed as inert data.
+The analyzer uses `shlex.join` only to display them.
+
+Canary values are `pass`, `fail`, or `not_run`. A missing value behaves like
+`not_run`. Record results only after executing the target canary separately.
+
+## Rule document
+
+```json
+{
+  "schema_version": 1,
+  "rules": [
+    {
+      "id": "rename-example",
+      "category": "renamed_interface",
+      "severity": "required",
+      "title": "Example flag renamed",
+      "applies": {
+        "mode": "crossing",
+        "introduced_in": "v0.5.16",
+        "fixed_in": null
+      },
+      "source_url": "https://github.com/sgl-project/sglang/pull/1",
+      "summary": "The old spelling has no alias.",
+      "match": {
+        "all": [{"kind": "argv_flag", "name": "--old"}]
+      },
+      "transforms": [
+        {"kind": "rename_flag", "from": "--old", "to": "--new"}
+      ],
+      "canaries": ["server_health"],
+      "rollback": "Restore the prior image and argv."
+    }
+  ]
+}
+```
+
+`mode` is `crossing` or `target`. `fixed_in` is optional/null. Every rule needs
+a direct source, concrete summary, at least one predicate, explicit severity,
+canaries, and a rollback.
+
+## Predicates
+
+All predicates in `match.all` must pass:
+
+| Kind | Required fields | Match |
+| --- | --- | --- |
+| `argv_flag` | `name` | Exact token exists |
+| `argv_value` | `name`, `equals` | Exact flag token followed by exact value |
+| `env` | `name`, optional `equals` | Variable exists or equals value |
+| `feature` | `value` | Value in `features` |
+| `guarantee` | `value` | Value in `guarantees` |
+| `integration` | `value` | Value in `integrations` |
+| `import_prefix` | `value` | Exact import/prefix exists |
+| `model_family` | `equals` | Exact model family |
+| `quantization` | `equals` | Exact quantization |
+| `hardware` | `equals` | Exact hardware label |
+| `topology` | `name`, `equals`/`min`/`max` | Integer topology constraint |
+
+Keep profile vocabulary stable within one audit. The analyzer does not infer
+that two model-family aliases are equivalent.
+
+## Transformations
+
+### `rename_flag`
+
+```json
+{"kind": "rename_flag", "from": "--old", "to": "--new"}
+```
+
+Replace one exact flag token. Duplicate occurrences are ambiguous and rejected.
+
+### `remove_flag`
+
+```json
+{"kind": "remove_flag", "name": "--removed", "arity": 1}
+```
+
+Remove the flag and zero or one following value. Only arity 0 or 1 is accepted.
+
+### `replace_value`
+
+```json
+{
+  "kind": "replace_value",
+  "flag": "--backend",
+  "from": "old",
+  "to": "auto"
+}
+```
+
+Require the exact old value before proposing the replacement.
+
+### `replace_import_prefix`
+
+```json
+{
+  "kind": "replace_import_prefix",
+  "from": "sglang.jit_kernel",
+  "to": "sglang.kernels"
+}
+```
+
+Rewrite only exact imports or dotted children. Use only for source-proven,
+prefix-preserving moves.
+
+Conflicting transforms on the same flag/import prefix produce `NO_GO`. The
+analyzer keeps original argv/imports when it cannot apply the proposal safely.
+
+## Verdicts and result
+
+The result contains:
+
+```json
+{
+  "schema_version": 1,
+  "fixture": false,
+  "current_version": "v0.5.15",
+  "target_version": "v0.5.16",
+  "overall_verdict": "CONDITIONAL_GO",
+  "profiles": [
+    {
+      "id": "production-pd",
+      "verdict": "CONDITIONAL_GO",
+      "original_argv": [],
+      "proposed_argv": [],
+      "original_imports": [],
+      "proposed_imports": [],
+      "findings": [],
+      "required_canaries": [],
+      "canary_results": {},
+      "missing_or_failing_canaries": [],
+      "transform_error": null,
+      "coverage_gaps": []
+    }
+  ]
+}
+```
+
+Overall verdict is the most restrictive profile verdict:
+`NO_GO > CONDITIONAL_GO > GO`.
+
+- `NO_GO`: blocker or transform conflict.
+- `CONDITIONAL_GO`: required/behavior/risk/dependency finding or incomplete
+  canary.
+- `GO`: no conditional finding remains and all base/matched canaries pass.
+
+`coverage_gaps` lists profile features that no target-applicable feature rule
+covers. Review gaps manually; the analyzer cannot know whether every arbitrary
+feature is high-risk.
+
+## Safety and fixtures
+
+The analyzer reads and writes files only. It never executes argv arrays,
+imports user modules, reads environment variables named in a profile, pulls an
+image, or changes deployment state.
+
+Set `fixture: true` for synthetic examples. Preserve the **SYNTHETIC FIXTURE**
+warning in generated Markdown and never use fixture verdicts as production
+upgrade evidence.

--- a/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+++ b/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
@@ -219,3 +219,85 @@ def validate_rules(document: dict[str, Any]) -> None:
             if transform.get("kind") not in VALID_TRANSFORMS:
                 raise ValueError(f"{rule_id}: unknown transform")
         _require_string_list(rule.get("canaries", []), f"{rule_id}.canaries")
+
+
+def rule_applies(
+    rule: dict[str, Any],
+    current: str,
+    target: str,
+) -> bool:
+    current_version = parse_version(current)
+    target_version = parse_version(target)
+    introduced = parse_version(rule["applies"]["introduced_in"])
+    fixed_text = rule["applies"].get("fixed_in")
+    if fixed_text is not None and target_version >= parse_version(fixed_text):
+        return False
+    mode = rule["applies"].get("mode", "crossing")
+    if mode == "target":
+        return target_version >= introduced
+    return current_version < introduced <= target_version
+
+
+def _flag_index(argv: list[str], name: str) -> int | None:
+    try:
+        return argv.index(name)
+    except ValueError:
+        return None
+
+
+def _predicate_matches(
+    predicate: dict[str, Any],
+    profile: dict[str, Any],
+) -> bool:
+    kind = predicate["kind"]
+    if kind == "argv_flag":
+        return _flag_index(profile["argv"], predicate["name"]) is not None
+    if kind == "argv_value":
+        index = _flag_index(profile["argv"], predicate["name"])
+        return (
+            index is not None
+            and index + 1 < len(profile["argv"])
+            and profile["argv"][index + 1] == predicate["equals"]
+        )
+    if kind == "env":
+        value = profile.get("env", {}).get(predicate["name"])
+        if "equals" in predicate:
+            return value == predicate["equals"]
+        return value is not None
+    if kind in {"feature", "guarantee", "integration"}:
+        collection_name = {
+            "feature": "features",
+            "guarantee": "guarantees",
+            "integration": "integrations",
+        }[kind]
+        return predicate["value"] in profile.get(collection_name, [])
+    if kind == "import_prefix":
+        prefix = predicate["value"]
+        return any(
+            value == prefix or value.startswith(prefix + ".")
+            for value in profile.get("imports", [])
+        )
+    if kind in {"model_family", "quantization", "hardware"}:
+        return profile.get(kind) == predicate["equals"]
+    if kind == "topology":
+        value = profile.get("topology", {}).get(predicate["name"])
+        if not isinstance(value, int) or isinstance(value, bool):
+            return False
+        if "equals" in predicate and value != predicate["equals"]:
+            return False
+        if "min" in predicate and value < predicate["min"]:
+            return False
+        if "max" in predicate and value > predicate["max"]:
+            return False
+        return True
+    raise ValueError(f"unsupported predicate: {kind}")
+
+
+def rule_matches(
+    rule: dict[str, Any],
+    profile: dict[str, Any],
+) -> bool:
+    return all(
+        _predicate_matches(predicate, profile)
+        for predicate in rule["match"]["all"]
+    )

--- a/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+++ b/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
@@ -385,3 +385,283 @@ def apply_transforms(
                 for value in rewritten_imports
             ]
     return rewritten_argv, rewritten_imports
+
+
+def _finding(rule: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": rule["id"],
+        "category": rule["category"],
+        "severity": rule["severity"],
+        "title": rule["title"],
+        "source_url": rule["source_url"],
+        "summary": rule["summary"],
+        "transforms": rule.get("transforms", []),
+        "canaries": rule.get("canaries", []),
+        "rollback": rule["rollback"],
+    }
+
+
+def _coverage_gaps(
+    profile: dict[str, Any],
+    applicable_rules: list[dict[str, Any]],
+) -> list[str]:
+    covered_features = {
+        predicate["value"]
+        for rule in applicable_rules
+        for predicate in rule["match"]["all"]
+        if predicate["kind"] == "feature"
+    }
+    return sorted(set(profile.get("features", [])) - covered_features)
+
+
+def audit(
+    profiles_document: dict[str, Any],
+    rules_document: dict[str, Any],
+) -> dict[str, Any]:
+    validate_profiles(profiles_document)
+    validate_rules(rules_document)
+    audit_contract = profiles_document["audit"]
+    current = audit_contract["current_version"]
+    target = audit_contract["target_version"]
+    base_canaries = set(audit_contract.get("required_canaries", []))
+    applicable_rules = [
+        rule
+        for rule in rules_document["rules"]
+        if rule_applies(rule, current, target)
+    ]
+
+    profile_results: list[dict[str, Any]] = []
+    for profile in sorted(profiles_document["profiles"], key=lambda item: item["id"]):
+        matched_rules = [
+            rule for rule in applicable_rules if rule_matches(rule, profile)
+        ]
+        findings = [_finding(rule) for rule in matched_rules]
+        transforms = [
+            transform
+            for rule in matched_rules
+            for transform in rule.get("transforms", [])
+        ]
+        transform_error: str | None = None
+        try:
+            proposed_argv, proposed_imports = apply_transforms(
+                profile["argv"],
+                profile.get("imports", []),
+                transforms,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            proposed_argv = list(profile["argv"])
+            proposed_imports = list(profile.get("imports", []))
+            transform_error = str(exc)
+
+        required_canaries = set(base_canaries)
+        for rule in matched_rules:
+            required_canaries.update(rule.get("canaries", []))
+        canary_results = profile.get("canary_results", {})
+        missing_or_failing = sorted(
+            canary
+            for canary in required_canaries
+            if canary_results.get(canary) != "pass"
+        )
+
+        severities = {rule["severity"] for rule in matched_rules}
+        if transform_error or "blocker" in severities:
+            verdict = "NO_GO"
+        elif (
+            severities & {"required", "behavior", "risk", "dependency"}
+            or missing_or_failing
+        ):
+            verdict = "CONDITIONAL_GO"
+        else:
+            verdict = "GO"
+
+        profile_results.append(
+            {
+                "id": profile["id"],
+                "verdict": verdict,
+                "original_argv": profile["argv"],
+                "proposed_argv": proposed_argv,
+                "original_imports": profile.get("imports", []),
+                "proposed_imports": proposed_imports,
+                "findings": findings,
+                "required_canaries": sorted(required_canaries),
+                "canary_results": canary_results,
+                "missing_or_failing_canaries": missing_or_failing,
+                "transform_error": transform_error,
+                "coverage_gaps": _coverage_gaps(profile, applicable_rules),
+            }
+        )
+
+    verdict_rank = {"GO": 0, "CONDITIONAL_GO": 1, "NO_GO": 2}
+    overall = max(
+        (profile["verdict"] for profile in profile_results),
+        key=lambda verdict: verdict_rank[verdict],
+    )
+    return {
+        "schema_version": 1,
+        "fixture": profiles_document.get("fixture") is True,
+        "current_version": current,
+        "target_version": target,
+        "overall_verdict": overall,
+        "profiles": profile_results,
+    }
+
+
+def _cell(value: Any) -> str:
+    return str(value).replace("\n", "<br>").replace("|", "\\|")
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    lines = ["# SGLang Upgrade Readiness Audit", ""]
+    if result["fixture"]:
+        lines.extend(
+            [
+                "> **SYNTHETIC FIXTURE:** Deployment profiles and canary "
+                "results are invented for analyzer demonstration.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            f"- Current: `{_cell(result['current_version'])}`",
+            f"- Target: `{_cell(result['target_version'])}`",
+            f"- Overall verdict: **{_cell(result['overall_verdict'])}**",
+            "- Safety: read-only analysis; no command below was executed.",
+            "",
+            "## Profile Verdicts",
+            "",
+            "| Profile | Verdict | Findings | Proposed changes | "
+            "Missing/failing canaries | Coverage gaps |",
+            "| --- | --- | ---: | --- | --- | --- |",
+        ]
+    )
+    for profile in result["profiles"]:
+        changed = (
+            profile["original_argv"] != profile["proposed_argv"]
+            or profile["original_imports"] != profile["proposed_imports"]
+        )
+        lines.append(
+            f"| `{_cell(profile['id'])}` | **{_cell(profile['verdict'])}** | "
+            f"{len(profile['findings'])} | {'yes' if changed else 'no'} | "
+            f"{_cell(', '.join(profile['missing_or_failing_canaries']) or 'none')} | "
+            f"{_cell(', '.join(profile['coverage_gaps']) or 'none')} |"
+        )
+
+    lines.extend(["", "## Findings", ""])
+    if not any(profile["findings"] for profile in result["profiles"]):
+        lines.append("No deployment-specific rule matched.")
+    for profile in result["profiles"]:
+        if not profile["findings"] and not profile["transform_error"]:
+            continue
+        lines.extend([f"### `{_cell(profile['id'])}`", ""])
+        if profile["transform_error"]:
+            lines.append(
+                f"- **BLOCKER:** transformation conflict: "
+                f"`{_cell(profile['transform_error'])}`"
+            )
+        for finding in profile["findings"]:
+            lines.append(
+                f"- **{_cell(finding['severity'].upper())}** "
+                f"`{_cell(finding['id'])}` — {_cell(finding['title'])}. "
+                f"{_cell(finding['summary'])} "
+                f"([source]({_cell(finding['source_url'])}))"
+            )
+        lines.append("")
+
+    lines.extend(["## Proposed Commands", ""])
+    for profile in result["profiles"]:
+        lines.extend(
+            [
+                f"### `{_cell(profile['id'])}`",
+                "",
+                "Original argv:",
+                "",
+                "```bash",
+                shlex.join(profile["original_argv"]),
+                "```",
+                "",
+                "Proposed argv:",
+                "",
+                "```bash",
+                shlex.join(profile["proposed_argv"]),
+                "```",
+                "",
+            ]
+        )
+        if profile["original_imports"] != profile["proposed_imports"]:
+            lines.extend(
+                [
+                    "Proposed imports:",
+                    "",
+                    "```text",
+                    "\n".join(profile["proposed_imports"]),
+                    "```",
+                    "",
+                ]
+            )
+
+    lines.extend(["## Canaries and Rollback", ""])
+    for profile in result["profiles"]:
+        lines.extend([f"### `{_cell(profile['id'])}`", ""])
+        lines.append(
+            "- Required canaries: "
+            + _cell(", ".join(profile["required_canaries"]) or "none")
+        )
+        lines.append(
+            "- Missing/failing: "
+            + _cell(", ".join(profile["missing_or_failing_canaries"]) or "none")
+        )
+        rollbacks = sorted(
+            {finding["rollback"] for finding in profile["findings"]}
+        )
+        if rollbacks:
+            lines.extend(f"- Rollback: {_cell(rollback)}" for rollback in rollbacks)
+        else:
+            lines.append("- Rollback: restore the recorded current version and argv.")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Interpretation",
+            "",
+            "- `GO`: no blocking or conditional finding remains and all required "
+            "canaries are recorded as passing.",
+            "- `CONDITIONAL_GO`: apply/review proposed changes or complete "
+            "required canaries before rollout.",
+            "- `NO_GO`: resolve the blocker or choose a different target/configuration.",
+            "- Review every proposed argv. This auditor never executes it.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit SGLang version changes against deployment profiles."
+    )
+    parser.add_argument("--profiles", required=True, type=Path)
+    parser.add_argument("--rules", required=True, type=Path)
+    parser.add_argument("--output-markdown", required=True, type=Path)
+    parser.add_argument("--output-json", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        profiles = _load_json_object(args.profiles, "profile")
+        rules = _load_json_object(args.rules, "rule")
+        result = audit(profiles, rules)
+        args.output_markdown.write_text(render_markdown(result), encoding="utf-8")
+        args.output_json.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+++ b/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:\.post(\d+))?$")
 VALID_SEVERITIES = {
     "blocker",
@@ -91,16 +90,12 @@ def validate_profiles(document: dict[str, Any]) -> None:
     current_text = _require_string(
         audit.get("current_version"), "audit.current_version"
     )
-    target_text = _require_string(
-        audit.get("target_version"), "audit.target_version"
-    )
+    target_text = _require_string(audit.get("target_version"), "audit.target_version")
     current = parse_version(current_text)
     target = parse_version(target_text)
     if current >= target:
         raise ValueError("target_version must be newer than current_version")
-    _require_string_list(
-        audit.get("required_canaries", []), "audit.required_canaries"
-    )
+    _require_string_list(audit.get("required_canaries", []), "audit.required_canaries")
 
     profiles = document.get("profiles")
     if not isinstance(profiles, list) or not profiles:
@@ -128,9 +123,7 @@ def validate_profiles(document: dict[str, Any]) -> None:
                 raise ValueError(f"{profile_id}: env values must be strings")
         for field in ("model_family", "quantization", "hardware"):
             _require_string(profile.get(field), f"{profile_id}.{field}")
-        topology = _require_mapping(
-            profile.get("topology"), f"{profile_id}.topology"
-        )
+        topology = _require_mapping(profile.get("topology"), f"{profile_id}.topology")
         for name, value in topology.items():
             if (
                 not isinstance(name, str)
@@ -186,15 +179,11 @@ def validate_rules(document: dict[str, Any]) -> None:
         if applies.get("mode", "crossing") not in VALID_APPLICABILITY_MODES:
             raise ValueError(f"{rule_id}: invalid applicability mode")
         introduced = parse_version(
-            _require_string(
-                applies.get("introduced_in"), f"{rule_id}.introduced_in"
-            )
+            _require_string(applies.get("introduced_in"), f"{rule_id}.introduced_in")
         )
         fixed_text = applies.get("fixed_in")
         if fixed_text is not None:
-            fixed = parse_version(
-                _require_string(fixed_text, f"{rule_id}.fixed_in")
-            )
+            fixed = parse_version(_require_string(fixed_text, f"{rule_id}.fixed_in"))
             if fixed <= introduced:
                 raise ValueError(f"{rule_id}.fixed_in must follow introduced_in")
 
@@ -203,9 +192,7 @@ def validate_rules(document: dict[str, Any]) -> None:
         if not isinstance(predicates, list) or not predicates:
             raise ValueError(f"{rule_id}: match.all must be a non-empty array")
         for predicate_value in predicates:
-            predicate = _require_mapping(
-                predicate_value, f"{rule_id}.match predicate"
-            )
+            predicate = _require_mapping(predicate_value, f"{rule_id}.match predicate")
             if predicate.get("kind") not in VALID_PREDICATES:
                 raise ValueError(f"{rule_id}: unknown predicate")
 
@@ -213,9 +200,7 @@ def validate_rules(document: dict[str, Any]) -> None:
         if not isinstance(transforms, list):
             raise ValueError(f"{rule_id}.transforms must be an array")
         for transform_value in transforms:
-            transform = _require_mapping(
-                transform_value, f"{rule_id}.transform"
-            )
+            transform = _require_mapping(transform_value, f"{rule_id}.transform")
             if transform.get("kind") not in VALID_TRANSFORMS:
                 raise ValueError(f"{rule_id}: unknown transform")
         _require_string_list(rule.get("canaries", []), f"{rule_id}.canaries")
@@ -298,8 +283,7 @@ def rule_matches(
     profile: dict[str, Any],
 ) -> bool:
     return all(
-        _predicate_matches(predicate, profile)
-        for predicate in rule["match"]["all"]
+        _predicate_matches(predicate, profile) for predicate in rule["match"]["all"]
     )
 
 
@@ -359,9 +343,7 @@ def apply_transforms(
                     f"invalid removal arity for {transform['name']}: {arity}"
                 )
             if index + arity >= len(rewritten_argv):
-                raise ValueError(
-                    f"missing value for removal of {transform['name']}"
-                )
+                raise ValueError(f"missing value for removal of {transform['name']}")
             del rewritten_argv[index : index + arity + 1]
         elif kind == "replace_value":
             index = _single_flag_index(rewritten_argv, transform["flag"])
@@ -371,17 +353,17 @@ def apply_transforms(
                 )
             actual = rewritten_argv[index + 1]
             if actual != transform["from"]:
-                raise ValueError(
-                    f"unexpected value for {transform['flag']}: {actual}"
-                )
+                raise ValueError(f"unexpected value for {transform['flag']}: {actual}")
             rewritten_argv[index + 1] = transform["to"]
         elif kind == "replace_import_prefix":
             source = transform["from"]
             target = transform["to"]
             rewritten_imports = [
-                target + value[len(source) :]
-                if value == source or value.startswith(source + ".")
-                else value
+                (
+                    target + value[len(source) :]
+                    if value == source or value.startswith(source + ".")
+                    else value
+                )
                 for value in rewritten_imports
             ]
     return rewritten_argv, rewritten_imports
@@ -425,9 +407,7 @@ def audit(
     target = audit_contract["target_version"]
     base_canaries = set(audit_contract.get("required_canaries", []))
     applicable_rules = [
-        rule
-        for rule in rules_document["rules"]
-        if rule_applies(rule, current, target)
+        rule for rule in rules_document["rules"] if rule_applies(rule, current, target)
     ]
 
     profile_results: list[dict[str, Any]] = []
@@ -610,9 +590,7 @@ def render_markdown(result: dict[str, Any]) -> str:
             "- Missing/failing: "
             + _cell(", ".join(profile["missing_or_failing_canaries"]) or "none")
         )
-        rollbacks = sorted(
-            {finding["rollback"] for finding in profile["findings"]}
-        )
+        rollbacks = sorted({finding["rollback"] for finding in profile["findings"]})
         if rollbacks:
             lines.extend(f"- Rollback: {_cell(rollback)}" for rollback in rollbacks)
         else:

--- a/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+++ b/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
@@ -301,3 +301,87 @@ def rule_matches(
         _predicate_matches(predicate, profile)
         for predicate in rule["match"]["all"]
     )
+
+
+def _transform_key(transform: dict[str, Any]) -> tuple[str, str]:
+    kind = transform["kind"]
+    if kind == "rename_flag":
+        return "argv_flag", transform["from"]
+    if kind == "remove_flag":
+        return "argv_flag", transform["name"]
+    if kind == "replace_value":
+        return "argv_flag", transform["flag"]
+    return "import_prefix", transform["from"]
+
+
+def detect_transform_conflicts(transforms: list[dict[str, Any]]) -> None:
+    seen: dict[tuple[str, str], str] = {}
+    for transform in transforms:
+        key = _transform_key(transform)
+        rendered = json.dumps(transform, sort_keys=True)
+        if key in seen and seen[key] != rendered:
+            raise ValueError(f"conflicting transformations for {key[1]}")
+        seen[key] = rendered
+
+
+def _single_flag_index(argv: list[str], name: str) -> int:
+    indices = [index for index, token in enumerate(argv) if token == name]
+    if not indices:
+        raise ValueError(f"flag not found for transformation: {name}")
+    if len(indices) != 1:
+        raise ValueError(f"flag {name} appears {len(indices)} times")
+    return indices[0]
+
+
+def apply_transforms(
+    argv: list[str],
+    imports: list[str],
+    transforms: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    detect_transform_conflicts(transforms)
+    rewritten_argv = list(argv)
+    rewritten_imports = list(imports)
+    applied_signatures: set[str] = set()
+    for transform in transforms:
+        signature = json.dumps(transform, sort_keys=True)
+        if signature in applied_signatures:
+            continue
+        applied_signatures.add(signature)
+        kind = transform["kind"]
+        if kind == "rename_flag":
+            index = _single_flag_index(rewritten_argv, transform["from"])
+            rewritten_argv[index] = transform["to"]
+        elif kind == "remove_flag":
+            index = _single_flag_index(rewritten_argv, transform["name"])
+            arity = transform.get("arity", 0)
+            if arity not in {0, 1}:
+                raise ValueError(
+                    f"invalid removal arity for {transform['name']}: {arity}"
+                )
+            if index + arity >= len(rewritten_argv):
+                raise ValueError(
+                    f"missing value for removal of {transform['name']}"
+                )
+            del rewritten_argv[index : index + arity + 1]
+        elif kind == "replace_value":
+            index = _single_flag_index(rewritten_argv, transform["flag"])
+            if index + 1 >= len(rewritten_argv):
+                raise ValueError(
+                    f"missing value for replacement of {transform['flag']}"
+                )
+            actual = rewritten_argv[index + 1]
+            if actual != transform["from"]:
+                raise ValueError(
+                    f"unexpected value for {transform['flag']}: {actual}"
+                )
+            rewritten_argv[index + 1] = transform["to"]
+        elif kind == "replace_import_prefix":
+            source = transform["from"]
+            target = transform["to"]
+            rewritten_imports = [
+                target + value[len(source) :]
+                if value == source or value.startswith(source + ".")
+                else value
+                for value in rewritten_imports
+            ]
+    return rewritten_argv, rewritten_imports

--- a/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
+++ b/skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Audit SGLang version changes against concrete deployment profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:\.post(\d+))?$")
+VALID_SEVERITIES = {
+    "blocker",
+    "required",
+    "behavior",
+    "risk",
+    "dependency",
+    "info",
+}
+VALID_TRANSFORMS = {
+    "rename_flag",
+    "remove_flag",
+    "replace_value",
+    "replace_import_prefix",
+}
+VALID_PREDICATES = {
+    "argv_flag",
+    "argv_value",
+    "env",
+    "feature",
+    "guarantee",
+    "integration",
+    "import_prefix",
+    "model_family",
+    "quantization",
+    "hardware",
+    "topology",
+}
+VALID_APPLICABILITY_MODES = {"crossing", "target"}
+VALID_CANARY_RESULTS = {"pass", "fail", "not_run"}
+
+
+def parse_version(value: str) -> tuple[int, int, int, int]:
+    if not isinstance(value, str):
+        raise ValueError("SGLang version must be a string")
+    match = VERSION_RE.fullmatch(value)
+    if not match:
+        raise ValueError(f"unsupported SGLang version: {value}")
+    major, minor, patch, post = match.groups()
+    return int(major), int(minor), int(patch), int(post or 0)
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise ValueError(f"{label} must be a string array")
+    return value
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} root must be an object")
+    return value
+
+
+def validate_profiles(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("profile schema_version must be 1")
+    if "fixture" in document and not isinstance(document["fixture"], bool):
+        raise ValueError("fixture must be boolean")
+
+    audit = _require_mapping(document.get("audit"), "audit")
+    current_text = _require_string(
+        audit.get("current_version"), "audit.current_version"
+    )
+    target_text = _require_string(
+        audit.get("target_version"), "audit.target_version"
+    )
+    current = parse_version(current_text)
+    target = parse_version(target_text)
+    if current >= target:
+        raise ValueError("target_version must be newer than current_version")
+    _require_string_list(
+        audit.get("required_canaries", []), "audit.required_canaries"
+    )
+
+    profiles = document.get("profiles")
+    if not isinstance(profiles, list) or not profiles:
+        raise ValueError("profiles must be a non-empty array")
+    profile_ids: set[str] = set()
+    for index, profile_value in enumerate(profiles):
+        profile = _require_mapping(profile_value, f"profile {index}")
+        profile_id = _require_string(profile.get("id"), f"profile {index}.id")
+        if profile_id in profile_ids:
+            raise ValueError(f"duplicate profile id: {profile_id}")
+        profile_ids.add(profile_id)
+
+        argv = profile.get("argv")
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(token, str) and token for token in argv)
+        ):
+            raise ValueError(f"{profile_id}: argv must be a non-empty string array")
+        env = _require_mapping(profile.get("env", {}), f"{profile_id}.env")
+        for name, value in env.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"{profile_id}: env names must be non-empty strings")
+            if not isinstance(value, str):
+                raise ValueError(f"{profile_id}: env values must be strings")
+        for field in ("model_family", "quantization", "hardware"):
+            _require_string(profile.get(field), f"{profile_id}.{field}")
+        topology = _require_mapping(
+            profile.get("topology"), f"{profile_id}.topology"
+        )
+        for name, value in topology.items():
+            if (
+                not isinstance(name, str)
+                or not name
+                or not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 1
+            ):
+                raise ValueError(
+                    f"{profile_id}.topology values must be positive integers"
+                )
+        for field in ("features", "guarantees", "integrations", "imports"):
+            _require_string_list(profile.get(field, []), f"{profile_id}.{field}")
+        canary_results = _require_mapping(
+            profile.get("canary_results", {}), f"{profile_id}.canary_results"
+        )
+        for name, value in canary_results.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    f"{profile_id}: canary names must be non-empty strings"
+                )
+            if value not in VALID_CANARY_RESULTS:
+                raise ValueError(
+                    f"{profile_id}.{name}: canary result must be pass, fail, or not_run"
+                )
+
+
+def validate_rules(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("rule schema_version must be 1")
+    rules = document.get("rules")
+    if not isinstance(rules, list):
+        raise ValueError("rules must be an array")
+
+    rule_ids: set[str] = set()
+    for index, rule_value in enumerate(rules):
+        rule = _require_mapping(rule_value, f"rule {index}")
+        rule_id = _require_string(rule.get("id"), f"rule {index}.id")
+        if rule_id in rule_ids:
+            raise ValueError(f"duplicate rule id: {rule_id}")
+        rule_ids.add(rule_id)
+        _require_string(rule.get("category"), f"{rule_id}.category")
+        if rule.get("severity") not in VALID_SEVERITIES:
+            raise ValueError(f"{rule_id}: invalid severity")
+        _require_string(rule.get("title"), f"{rule_id}.title")
+        source_url = _require_string(rule.get("source_url"), f"{rule_id}.source_url")
+        if not source_url.startswith(("https://", "http://")):
+            raise ValueError(f"{rule_id}.source_url must be an HTTP URL")
+        _require_string(rule.get("summary"), f"{rule_id}.summary")
+        _require_string(rule.get("rollback"), f"{rule_id}.rollback")
+
+        applies = _require_mapping(rule.get("applies"), f"{rule_id}.applies")
+        if applies.get("mode", "crossing") not in VALID_APPLICABILITY_MODES:
+            raise ValueError(f"{rule_id}: invalid applicability mode")
+        introduced = parse_version(
+            _require_string(
+                applies.get("introduced_in"), f"{rule_id}.introduced_in"
+            )
+        )
+        fixed_text = applies.get("fixed_in")
+        if fixed_text is not None:
+            fixed = parse_version(
+                _require_string(fixed_text, f"{rule_id}.fixed_in")
+            )
+            if fixed <= introduced:
+                raise ValueError(f"{rule_id}.fixed_in must follow introduced_in")
+
+        match = _require_mapping(rule.get("match"), f"{rule_id}.match")
+        predicates = match.get("all")
+        if not isinstance(predicates, list) or not predicates:
+            raise ValueError(f"{rule_id}: match.all must be a non-empty array")
+        for predicate_value in predicates:
+            predicate = _require_mapping(
+                predicate_value, f"{rule_id}.match predicate"
+            )
+            if predicate.get("kind") not in VALID_PREDICATES:
+                raise ValueError(f"{rule_id}: unknown predicate")
+
+        transforms = rule.get("transforms", [])
+        if not isinstance(transforms, list):
+            raise ValueError(f"{rule_id}.transforms must be an array")
+        for transform_value in transforms:
+            transform = _require_mapping(
+                transform_value, f"{rule_id}.transform"
+            )
+            if transform.get("kind") not in VALID_TRANSFORMS:
+                raise ValueError(f"{rule_id}: unknown transform")
+        _require_string_list(rule.get("canaries", []), f"{rule_id}.canaries")

--- a/tests/test_model_pr_dossier_quality.py
+++ b/tests/test_model_pr_dossier_quality.py
@@ -202,7 +202,7 @@ def test_readme_installs_model_pr_diff_dossier_skill() -> None:
     assert "[`model-pr-diff-dossier`]" in readme
     assert f'ln -s "$PWD/{skill_path}" ~/.claude/skills/model-pr-diff-dossier' in readme
     assert f"cp -R {skill_path} <agent-skill-dir>/model-pr-diff-dossier" in readme
-    assert "After reload, the 12 skills appear" in readme
+    assert "After reload, the 13 skills appear" in readme
 
 
 def test_rebuild_history_dry_run_does_not_update_indexes(tmp_path) -> None:

--- a/tests/test_repository_metadata.py
+++ b/tests/test_repository_metadata.py
@@ -16,7 +16,7 @@ def test_readme_uses_current_claude_and_codex_launch_commands() -> None:
     assert "codex --yolo" not in readme
     assert "`opus`" in readme and "current Opus" in readme
     assert "bypassPermissions" in readme and "isolated" in readme
-    assert "core_skills-11" in readme
+    assert "core_skills-12" in readme
 
 
 def test_marketplace_has_top_level_description() -> None:
@@ -27,6 +27,20 @@ def test_marketplace_has_top_level_description() -> None:
     assert marketplace["description"]
     assert "LLM serving" in marketplace["description"]
     assert marketplace["plugins"][0]["description"]
+
+
+def test_upgrade_readiness_auditor_is_registered() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+
+    assert "sglang-upgrade-readiness-auditor" in readme
+    assert "upgrade" in plugin["description"].lower()
+    assert "upgrade" in marketplace["plugins"][0]["description"].lower()
 
 
 def test_precommit_versions_are_current_verified_tags() -> None:

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -280,5 +280,123 @@ class TransformationTest(unittest.TestCase):
             )
 
 
+class AuditVerdictTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_unmatched_profile_with_passing_base_canaries_is_go(self) -> None:
+        result = self.mod.audit(valid_profiles(), valid_rules())
+
+        self.assertEqual(result["profiles"][0]["verdict"], "GO")
+        self.assertEqual(result["overall_verdict"], "GO")
+
+    def test_required_rewrite_is_conditional_go(self) -> None:
+        profiles = valid_profiles()
+        profiles["profiles"][0]["argv"].append("--enable-deepep-waterfill")
+
+        result = self.mod.audit(profiles, valid_rules())
+        profile = result["profiles"][0]
+
+        self.assertEqual(profile["verdict"], "CONDITIONAL_GO")
+        self.assertIn("--enable-waterfill", profile["proposed_argv"])
+        self.assertNotIn("--enable-deepep-waterfill", profile["proposed_argv"])
+        self.assertEqual(profile["findings"][0]["id"], "rename-waterfill")
+
+    def test_unresolved_blocker_is_no_go(self) -> None:
+        profiles = valid_profiles()
+        profile = profiles["profiles"][0]
+        profile["features"].extend(
+            ["dp_attention", "breakable_prefill_cuda_graph"]
+        )
+        profile["guarantees"].append("temperature_zero_determinism")
+        rules = valid_rules()
+        rules["rules"].append(
+            {
+                "id": "determinism-known-issue",
+                "category": "known_issue",
+                "severity": "blocker",
+                "title": "Temperature-zero nondeterminism",
+                "applies": {
+                    "mode": "target",
+                    "introduced_in": "v0.5.16",
+                    "fixed_in": None,
+                },
+                "source_url": "https://github.com/sgl-project/sglang/pull/31125",
+                "summary": "Avoid the affected graph path.",
+                "match": {
+                    "all": [
+                        {"kind": "feature", "value": "dp_attention"},
+                        {
+                            "kind": "feature",
+                            "value": "breakable_prefill_cuda_graph",
+                        },
+                        {
+                            "kind": "guarantee",
+                            "value": "temperature_zero_determinism",
+                        },
+                    ]
+                },
+                "transforms": [],
+                "canaries": ["temperature_zero_determinism"],
+                "rollback": "Disable the affected graph path or restore v0.5.15.",
+            }
+        )
+
+        result = self.mod.audit(profiles, rules)
+
+        self.assertEqual(result["profiles"][0]["verdict"], "NO_GO")
+        self.assertEqual(result["overall_verdict"], "NO_GO")
+        self.assertIn(
+            "temperature_zero_determinism",
+            result["profiles"][0]["missing_or_failing_canaries"],
+        )
+
+    def test_markdown_labels_fixture_and_shows_commands(self) -> None:
+        profiles = valid_profiles()
+        profiles["profiles"][0]["argv"].append("--enable-deepep-waterfill")
+
+        result = self.mod.audit(profiles, valid_rules())
+        report = self.mod.render_markdown(result)
+
+        self.assertIn("SYNTHETIC FIXTURE", report)
+        self.assertIn("## Profile Verdicts", report)
+        self.assertIn("## Findings", report)
+        self.assertIn("## Proposed Commands", report)
+        self.assertIn("--enable-waterfill", report)
+        self.assertIn("github.com/sgl-project/sglang/pull/27350", report)
+        self.assertIn("## Canaries and Rollback", report)
+
+    def test_cli_writes_reports_without_executing_argv(self) -> None:
+        profiles = valid_profiles()
+        rules = valid_rules()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile_path = root / "profiles.json"
+            rule_path = root / "rules.json"
+            markdown_path = root / "report.md"
+            json_path = root / "report.json"
+            profile_path.write_text(json.dumps(profiles), encoding="utf-8")
+            rule_path.write_text(json.dumps(rules), encoding="utf-8")
+
+            exit_code = self.mod.main(
+                [
+                    "--profiles",
+                    str(profile_path),
+                    "--rules",
+                    str(rule_path),
+                    "--output-markdown",
+                    str(markdown_path),
+                    "--output-json",
+                    str(json_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("SYNTHETIC FIXTURE", markdown_path.read_text("utf-8"))
+            self.assertEqual(
+                json.loads(json_path.read_text("utf-8"))["overall_verdict"], "GO"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -146,5 +146,55 @@ class SchemaAndVersionTest(unittest.TestCase):
             self.mod.validate_profiles(document)
 
 
+class RuleMatchingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_crossing_rule_applies_only_when_upgrade_crosses_introduction(self) -> None:
+        rule = valid_rules()["rules"][0]
+
+        self.assertTrue(self.mod.rule_applies(rule, "v0.5.15", "v0.5.16"))
+        self.assertFalse(self.mod.rule_applies(rule, "v0.5.16", "v0.5.17"))
+
+    def test_target_rule_persists_until_fixed_version(self) -> None:
+        rule = valid_rules()["rules"][0]
+        rule["applies"] = {
+            "mode": "target",
+            "introduced_in": "v0.5.16",
+            "fixed_in": "v0.5.18",
+        }
+
+        self.assertTrue(self.mod.rule_applies(rule, "v0.5.16", "v0.5.17"))
+        self.assertFalse(self.mod.rule_applies(rule, "v0.5.17", "v0.5.18"))
+
+    def test_all_predicates_must_match(self) -> None:
+        profile = valid_profiles()["profiles"][0]
+        profile["env"]["SGLANG_TEST_MODE"] = "compact"
+        profile["imports"] = ["sglang.jit_kernel.fast_op"]
+        profile["features"] = ["breakable_prefill_cuda_graph"]
+        rule = valid_rules()["rules"][0]
+        rule["match"]["all"] = [
+            {"kind": "hardware", "equals": "b200"},
+            {"kind": "topology", "name": "tp", "min": 8},
+            {"kind": "feature", "value": "breakable_prefill_cuda_graph"},
+            {"kind": "env", "name": "SGLANG_TEST_MODE", "equals": "compact"},
+            {"kind": "import_prefix", "value": "sglang.jit_kernel"},
+            {"kind": "argv_value", "name": "--tp", "equals": "8"},
+        ]
+
+        self.assertTrue(self.mod.rule_matches(rule, profile))
+        profile["features"] = []
+        self.assertFalse(self.mod.rule_matches(rule, profile))
+
+    def test_unset_optional_predicate_does_not_match(self) -> None:
+        profile = valid_profiles()["profiles"][0]
+        rule = valid_rules()["rules"][0]
+        rule["match"]["all"] = [
+            {"kind": "integration", "value": "diffusion_rollout"}
+        ]
+
+        self.assertFalse(self.mod.rule_matches(rule, profile))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -437,5 +437,46 @@ class FixtureDemoTest(unittest.TestCase):
         )
 
 
+class SkillDocumentationTest(unittest.TestCase):
+    def test_skill_has_read_only_and_verdict_contract(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+        for required in [
+            "name: sglang-upgrade-readiness-auditor",
+            "read-only",
+            "immutable",
+            "GO",
+            "CONDITIONAL_GO",
+            "NO_GO",
+            "canary",
+            "rollback",
+            "never execute",
+            "SYNTHETIC FIXTURE",
+        ]:
+            self.assertIn(required, skill)
+        self.assertNotIn("TODO", skill)
+
+    def test_references_define_source_priority_and_safe_argv(self) -> None:
+        evidence = (
+            SKILL_ROOT / "references" / "evidence-and-rule-authoring.md"
+        ).read_text(encoding="utf-8")
+        schema = (
+            SKILL_ROOT / "references" / "profile-and-rule-schema.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Release", evidence)
+        self.assertIn("compare", evidence)
+        self.assertIn("argv arrays", schema)
+        self.assertIn("rename_flag", schema)
+
+    def test_openai_metadata_mentions_the_skill(self) -> None:
+        metadata = (SKILL_ROOT / "agents" / "openai.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("SGLang Upgrade Readiness Auditor", metadata)
+        self.assertIn("$sglang-upgrade-readiness-auditor", metadata)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -398,5 +398,44 @@ class AuditVerdictTest(unittest.TestCase):
             )
 
 
+class FixtureDemoTest(unittest.TestCase):
+    def test_v0516_fixture_report_is_reproducible(self) -> None:
+        module = load_module()
+        profiles = json.loads(
+            (
+                SKILL_ROOT
+                / "examples"
+                / "v0.5.15-to-v0.5.16-profiles.json"
+            ).read_text(encoding="utf-8")
+        )
+        rules = json.loads(
+            (
+                SKILL_ROOT / "examples" / "v0.5.15-to-v0.5.16-rules.json"
+            ).read_text(encoding="utf-8")
+        )
+
+        result = module.audit(profiles, rules)
+        generated = module.render_markdown(result)
+        committed = (SKILL_ROOT / "examples" / "fixture-report.md").read_text(
+            encoding="utf-8"
+        )
+        by_id = {profile["id"]: profile for profile in result["profiles"]}
+
+        self.assertEqual(generated, committed)
+        self.assertEqual(by_id["plain-tp"]["verdict"], "GO")
+        self.assertEqual(
+            by_id["legacy-fp4-pd"]["verdict"], "CONDITIONAL_GO"
+        )
+        self.assertEqual(
+            by_id["deterministic-dp-graph"]["verdict"], "NO_GO"
+        )
+        self.assertEqual(result["overall_verdict"], "NO_GO")
+        self.assertIn("--enable-waterfill", by_id["legacy-fp4-pd"]["proposed_argv"])
+        self.assertIn(
+            "sglang.kernels.fast_op",
+            by_id["legacy-fp4-pd"]["proposed_imports"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills" / "sglang-upgrade-readiness-auditor"
+SCRIPT = SKILL_ROOT / "scripts" / "audit_upgrade.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("upgrade_auditor", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_profiles() -> dict:
+    return {
+        "schema_version": 1,
+        "fixture": True,
+        "audit": {
+            "current_version": "v0.5.15",
+            "target_version": "v0.5.16",
+            "required_canaries": [
+                "server_health",
+                "correctness",
+                "performance",
+            ],
+        },
+        "profiles": [
+            {
+                "id": "plain-tp",
+                "argv": [
+                    "python3",
+                    "-m",
+                    "sglang.launch_server",
+                    "--model-path",
+                    "fixture/model",
+                    "--tp",
+                    "8",
+                ],
+                "env": {},
+                "model_family": "dense",
+                "quantization": "fp8",
+                "hardware": "b200",
+                "topology": {"tp": 8, "pp": 1, "dp": 1, "ep": 1, "cp": 1},
+                "features": [],
+                "guarantees": [],
+                "integrations": [],
+                "imports": [],
+                "canary_results": {
+                    "server_health": "pass",
+                    "correctness": "pass",
+                    "performance": "pass",
+                },
+            }
+        ],
+    }
+
+
+def valid_rules() -> dict:
+    return {
+        "schema_version": 1,
+        "rules": [
+            {
+                "id": "rename-waterfill",
+                "category": "required_change",
+                "severity": "required",
+                "title": "Waterfill flag renamed",
+                "applies": {
+                    "mode": "crossing",
+                    "introduced_in": "v0.5.16",
+                    "fixed_in": None,
+                },
+                "source_url": "https://github.com/sgl-project/sglang/pull/27350",
+                "summary": "The old flag has no deprecated alias.",
+                "match": {
+                    "all": [
+                        {
+                            "kind": "argv_flag",
+                            "name": "--enable-deepep-waterfill",
+                        }
+                    ]
+                },
+                "transforms": [
+                    {
+                        "kind": "rename_flag",
+                        "from": "--enable-deepep-waterfill",
+                        "to": "--enable-waterfill",
+                    }
+                ],
+                "canaries": ["server_health", "performance"],
+                "rollback": "Restore the prior SGLang image and argv.",
+            }
+        ],
+    }
+
+
+class SchemaAndVersionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_versions_support_post_releases(self) -> None:
+        self.assertLess(
+            self.mod.parse_version("v0.5.15"),
+            self.mod.parse_version("v0.5.15.post1"),
+        )
+
+    def test_valid_documents_are_accepted(self) -> None:
+        self.mod.validate_profiles(valid_profiles())
+        self.mod.validate_rules(valid_rules())
+
+    def test_duplicate_profile_id_is_rejected(self) -> None:
+        document = valid_profiles()
+        document["profiles"].append(copy.deepcopy(document["profiles"][0]))
+
+        with self.assertRaisesRegex(ValueError, "duplicate profile id"):
+            self.mod.validate_profiles(document)
+
+    def test_target_must_be_newer(self) -> None:
+        document = valid_profiles()
+        document["audit"]["target_version"] = "v0.5.15"
+
+        with self.assertRaisesRegex(ValueError, "newer"):
+            self.mod.validate_profiles(document)
+
+    def test_unknown_transform_is_rejected(self) -> None:
+        rules = valid_rules()
+        rules["rules"][0]["transforms"][0]["kind"] = "execute_shell"
+
+        with self.assertRaisesRegex(ValueError, "unknown transform"):
+            self.mod.validate_rules(rules)
+
+    def test_commands_must_be_argv_arrays(self) -> None:
+        document = valid_profiles()
+        document["profiles"][0]["argv"] = "python -m sglang.launch_server"
+
+        with self.assertRaisesRegex(ValueError, "argv"):
+            self.mod.validate_profiles(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_upgrade_readiness_auditor.py
+++ b/tests/test_upgrade_readiness_auditor.py
@@ -196,5 +196,89 @@ class RuleMatchingTest(unittest.TestCase):
         self.assertFalse(self.mod.rule_matches(rule, profile))
 
 
+class TransformationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_rename_and_replace_value_are_token_level(self) -> None:
+        argv = [
+            "python3",
+            "-m",
+            "sglang.launch_server",
+            "--enable-deepep-waterfill",
+            "--fp4-gemm-backend",
+            "cutlass",
+        ]
+        transforms = [
+            {
+                "kind": "rename_flag",
+                "from": "--enable-deepep-waterfill",
+                "to": "--enable-waterfill",
+            },
+            {
+                "kind": "replace_value",
+                "flag": "--fp4-gemm-backend",
+                "from": "cutlass",
+                "to": "auto",
+            },
+        ]
+
+        rewritten, imports = self.mod.apply_transforms(argv, [], transforms)
+
+        self.assertEqual(
+            rewritten,
+            [
+                "python3",
+                "-m",
+                "sglang.launch_server",
+                "--enable-waterfill",
+                "--fp4-gemm-backend",
+                "auto",
+            ],
+        )
+        self.assertEqual(imports, [])
+
+    def test_remove_flag_respects_arity(self) -> None:
+        rewritten, _ = self.mod.apply_transforms(
+            ["server", "--removed", "value", "--keep"],
+            [],
+            [{"kind": "remove_flag", "name": "--removed", "arity": 1}],
+        )
+
+        self.assertEqual(rewritten, ["server", "--keep"])
+
+    def test_import_prefix_is_rewritten_without_touching_other_imports(self) -> None:
+        _, imports = self.mod.apply_transforms(
+            ["server"],
+            ["sglang.jit_kernel.fast_op", "torch"],
+            [
+                {
+                    "kind": "replace_import_prefix",
+                    "from": "sglang.jit_kernel",
+                    "to": "sglang.kernels",
+                }
+            ],
+        )
+
+        self.assertEqual(imports, ["sglang.kernels.fast_op", "torch"])
+
+    def test_conflicting_rewrites_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "conflicting transformations"):
+            self.mod.detect_transform_conflicts(
+                [
+                    {"kind": "rename_flag", "from": "--old", "to": "--new-a"},
+                    {"kind": "rename_flag", "from": "--old", "to": "--new-b"},
+                ]
+            )
+
+    def test_ambiguous_duplicate_flag_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "appears 2 times"):
+            self.mod.apply_transforms(
+                ["server", "--old", "--old"],
+                [],
+                [{"kind": "rename_flag", "from": "--old", "to": "--new"}],
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add `sglang-upgrade-readiness-auditor`, a deployment-aware audit workflow for SGLang version upgrades
- match release rules against deployment profiles, classify findings as blocker/action/warning/info, and produce per-profile plus overall GO/CONDITIONAL_GO/NO_GO verdicts
- propose only bounded, reviewable command/import rewrites, with conflict detection and explicit coverage gaps
- include a deterministic synthetic v0.5.15 to v0.5.16 fixture grounded in upstream release and PR evidence
- register the skill in the repository README, plugin manifests, and metadata tests

## Why

Large SGLang releases can combine removed flags, renamed flags, changed defaults, import moves, hardware-specific behavior, and known issues. A changelog alone does not answer whether a concrete deployment is safe to upgrade. This skill maps upstream changes onto actual launch profiles and makes the remaining rollout work explicit.

## Demo

```bash
python3 skills/sglang-upgrade-readiness-auditor/scripts/audit_upgrade.py \
  --profiles skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-profiles.json \
  --rules skills/sglang-upgrade-readiness-auditor/examples/v0.5.15-to-v0.5.16-rules.json \
  --output-markdown /tmp/upgrade-report.md \
  --output-json /tmp/upgrade-report.json
```

The included synthetic fixture reports:

- `plain-tp`: GO
- `legacy-fp4-pd`: CONDITIONAL_GO, with reviewable rewrites for renamed/removed v0.5.16 flags and an import move
- `deterministic-dp-graph`: NO_GO because its stated determinism guarantee intersects the documented temperature-zero nondeterminism issue
- overall verdict: NO_GO until the blocker is resolved

The checked-in report is available at [fixture-report.md](../blob/codex/add-sglang-upgrade-readiness-auditor/skills/sglang-upgrade-readiness-auditor/examples/fixture-report.md).

## Safety and limits

The auditor is read-only: it never executes launch commands or mutates deployment files. Commands are parsed as inert argv arrays, transformations reject ambiguous/conflicting cases, and missing rule coverage is reported instead of silently assumed safe.

## Validation

- `python3 -m pytest -q`: 195 passed
- `pre-commit run --all-files --show-diff-on-failure`: passed
- skill-creator `quick_validate.py`: passed
- fixture report regeneration is deterministic
