### PR TITLE
Add SGLang speculative decoding autotuner skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
     {
       "name": "ai-infra-auto-driven-skills",
       "source": "./",
-      "description": "LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
+      "description": "LLM serving benchmarks, SGLang speculative decoding tuning, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
       "version": "0.1.0",
       "category": "ai-infra",
-      "tags": ["sglang", "vllm", "tensorrt-llm", "benchmarks", "profiler", "kernel", "moe", "llm-serving"]
+      "tags": ["sglang", "vllm", "tensorrt-llm", "benchmarks", "speculative", "profiler", "kernel", "moe", "llm-serving"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-infra-auto-driven-skills",
   "version": "0.1.0",
-  "description": "Agent-ready playbooks for LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
+  "description": "Agent-ready playbooks for LLM serving benchmarks, SGLang speculative decoding tuning, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
   "author": {
     "name": "BBuf",
     "url": "https://github.com/BBuf"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # AI-Infra-Auto-Driven-SKILLS
 
-**Agent-ready playbooks for LLM serving benchmarks, capacity planning,
-torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM
-optimization, human code review, production incidents, and model PR
-intelligence.**
+**Agent-ready playbooks for LLM serving benchmarks, speculative decoding
+tuning, capacity planning, torch-profiler triage, pipeline analysis, compute
+simulation, SGLang/vLLM optimization, human code review, production incidents,
+and model PR intelligence.**
 
 [![GitHub stars](https://img.shields.io/github/stars/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/forks)
 [![Last commit](https://img.shields.io/github/last-commit/BBuf/AI-Infra-Auto-Driven-SKILLS?style=flat-square)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/commits/main)
-[![Core skills](https://img.shields.io/badge/core_skills-11-2f80ed?style=flat-square)](#core-skills)
+[![Core skills](https://img.shields.io/badge/core_skills-12-2f80ed?style=flat-square)](#core-skills)
 [![PR histories](https://img.shields.io/badge/pr_histories-66-2ea44f?style=flat-square)](#model-pr-history-catalog)
 [![KDA-Pilot](https://img.shields.io/badge/sibling-KDA--Pilot-ff7b72?style=flat-square)](https://github.com/BBuf/KDA-Pilot)
 
@@ -20,10 +20,11 @@ This repository is built for AI infrastructure engineers who want agents to do
 real work, not recite generic prompts.
 
 It gives an agent the operational memory needed to benchmark SGLang, vLLM,
-TensorRT-LLM, and TokenSpeed fairly; explain serving capacity from startup logs;
-split prefill and decode profiler evidence; inspect traces at layer and kernel
-level; estimate operator FLOPs and MFU; review SGLang patches against real
-maintainer discussion patterns; run Humanize-governed SGLang and vLLM SOTA
+TensorRT-LLM, and TokenSpeed fairly; tune SGLang speculative decoding without
+sacrificing correctness or SLA gates; explain serving capacity from startup
+logs; split prefill and decode profiler evidence; inspect traces at layer and
+kernel level; estimate operator FLOPs and MFU; review SGLang patches against
+real maintainer discussion patterns; run Humanize-governed SGLang and vLLM SOTA
 loops; triage SGLang production incidents from a replay; and keep model-family
 optimization history close to the code that actually changed.
 
@@ -39,6 +40,7 @@ find it.
 | Skill | Use it when |
 | --- | --- |
 | [`llm-serving-auto-benchmark`](skills/llm-serving-auto-benchmark/) | You need a fair, bounded serving benchmark search for SGLang, vLLM, TensorRT-LLM, TokenSpeed, or another OpenAI-compatible stack. |
+| [`sglang-speculative-decoding-autotuner`](skills/sglang-speculative-decoding-autotuner/) | You need to compatibility-gate and benchmark baseline, MTP/EAGLE, DFlash, DSpark, or other revision-supported speculative paths, then select a safe Pareto-optimal configuration. |
 | [`llm-serving-capacity-planner`](skills/llm-serving-capacity-planner/) | You need to explain SGLang or vLLM startup memory, KV cache budget, request capacity, or OOM pressure from logs. |
 | [`llm-torch-profiler-analysis`](skills/llm-torch-profiler-analysis/) | You need a three-table profiler report that keeps `extend/prefill` and `decode` evidence separate. |
 | [`llm-pipeline-analysis`](skills/llm-pipeline-analysis/) | You need forward-pass, layer, and kernel-level timing from a torch profiler trace, including anchor boundaries and Perfetto ranges. |
@@ -128,6 +130,9 @@ The repo is opinionated about evidence because performance work gets noisy fast.
 - Benchmark rows should include model, framework, GPU count, workload, request
   rate or concurrency, SLA status, launch command, benchmark command, and raw
   artifacts.
+- Speculative decoding searches should prove compatibility against the selected
+  SGLang revision, keep a non-speculative baseline, and reject correctness,
+  determinism, memory, or SLA failures before ranking throughput.
 - Profiler reports should keep prefill and decode separate, then emit the same
   three tables: kernel table, overlap-opportunity table, and fuse-opportunity
   table.
@@ -169,7 +174,7 @@ installed as a single Claude Code plugin via the built-in marketplace flow:
 /reload-plugins
 ```
 
-After reload, the 12 skills appear namespaced as
+After reload, the 13 skills appear namespaced as
 `ai-infra-auto-driven-skills:<skill-name>` (for example
 `ai-infra-auto-driven-skills:sglang-sota-humanize-loop`). Update later with
 `/plugin marketplace update ai-infra-auto-driven-skills`.
@@ -186,6 +191,7 @@ cd AI-Infra-Auto-Driven-SKILLS
 
 mkdir -p ~/.claude/skills
 ln -s "$PWD/skills/llm-serving-auto-benchmark" ~/.claude/skills/llm-serving-auto-benchmark
+ln -s "$PWD/skills/sglang-speculative-decoding-autotuner" ~/.claude/skills/sglang-speculative-decoding-autotuner
 ln -s "$PWD/skills/llm-serving-capacity-planner" ~/.claude/skills/llm-serving-capacity-planner
 ln -s "$PWD/skills/llm-torch-profiler-analysis" ~/.claude/skills/llm-torch-profiler-analysis
 ln -s "$PWD/skills/llm-pipeline-analysis" ~/.claude/skills/llm-pipeline-analysis
@@ -201,6 +207,7 @@ ln -s "$PWD/model-pr-optimization-history" ~/.claude/skills/model-pr-history-kno
 
 Restart Claude Code after installing. The skills can then be invoked by name,
 for example `[$llm-serving-auto-benchmark]`,
+`[$sglang-speculative-decoding-autotuner]`,
 `[$llm-serving-capacity-planner]`, `[$llm-torch-profiler-analysis]`,
 `[$llm-pipeline-analysis]`, `[$model-compute-simulation]`,
 `[$model-pr-diff-dossier]`, `[$sglang-humanize-review]`,
@@ -218,6 +225,7 @@ directories into that runtime's skill directory:
 
 ```bash
 cp -R skills/llm-serving-auto-benchmark <agent-skill-dir>/llm-serving-auto-benchmark
+cp -R skills/sglang-speculative-decoding-autotuner <agent-skill-dir>/sglang-speculative-decoding-autotuner
 cp -R skills/llm-serving-capacity-planner <agent-skill-dir>/llm-serving-capacity-planner
 cp -R skills/llm-torch-profiler-analysis <agent-skill-dir>/llm-torch-profiler-analysis
 cp -R skills/llm-pipeline-analysis <agent-skill-dir>/llm-pipeline-analysis
@@ -262,6 +270,7 @@ correctness gates.
 ```text
 skills/
 ├── llm-serving-auto-benchmark/      # serving benchmark search and comparison
+├── sglang-speculative-decoding-autotuner/ # safe speculative config search
 ├── llm-serving-capacity-planner/     # startup memory and request capacity analysis
 ├── llm-torch-profiler-analysis/     # profiler capture and trace triage
 ├── llm-pipeline-analysis/           # forward/layer/kernel trace analysis

--- a/docs/superpowers/plans/2026-07-28-sglang-speculative-decoding-autotuner.md
+++ b/docs/superpowers/plans/2026-07-28-sglang-speculative-decoding-autotuner.md
@@ -1,0 +1,1056 @@
+# SGLang Speculative Decoding Autotuner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a version-aware SGLang skill that rejects unsafe speculative decoding candidates and deterministically recommends the best workload-specific configuration from measured evidence.
+
+**Architecture:** `SKILL.md` owns compatibility discovery and the bounded benchmark workflow. A standard-library Python analyzer owns measurement validation, hard gates, Pareto selection, objective ranking, and Markdown/JSON reports. Committed fixture inputs and reports demonstrate the decision logic without making GPU performance claims.
+
+**Tech Stack:** Markdown, Python 3.10+ standard library, `unittest`, JSON, repository pre-commit and link checks.
+
+---
+
+## File Structure
+
+- Create `skills/sglang-speculative-decoding-autotuner/SKILL.md`: operational workflow, trigger, safety gates, handoffs, and report contract.
+- Create `skills/sglang-speculative-decoding-autotuner/references/compatibility-and-search.md`: version-aware compatibility proof and bounded search guidance.
+- Create `skills/sglang-speculative-decoding-autotuner/references/measurement-schema.md`: exact JSON input/output schema.
+- Create `skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py`: deterministic validator, gate evaluator, Pareto selector, and CLI reporter.
+- Create `skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json`: synthetic candidate measurements.
+- Create `skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md`: generated, visibly labeled demo report.
+- Create `tests/test_speculative_decoding_autotuner.py`: analyzer, CLI, fixture, and documentation tests.
+- Modify `README.md`: register the new core skill, installation commands, examples, and count.
+- Modify `.claude-plugin/plugin.json`: mention speculative decoding tuning in the plugin description.
+- Modify `.claude-plugin/marketplace.json`: mention the new capability in discovery metadata.
+- Modify `tests/test_repository_metadata.py`: update the expected core-skill count and assert registration.
+
+### Task 1: Validate Measurement Documents
+
+**Files:**
+- Create: `tests/test_speculative_decoding_autotuner.py`
+- Create: `skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py`
+
+- [ ] **Step 1: Write the failing loader and schema tests**
+
+Create a module loader and a valid-document helper, then add tests for a valid
+document, duplicate candidate IDs, a missing baseline, and mixed experiment
+identity:
+
+```python
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "skills"
+    / "sglang-speculative-decoding-autotuner"
+    / "scripts"
+    / "analyze_candidates.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("spec_autotuner", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_document() -> dict:
+    return {
+        "schema_version": 1,
+        "fixture": True,
+        "experiment": {
+            "id": "fixture-search",
+            "model": "fixture/model",
+            "model_revision": "fixture-revision",
+            "sglang_revision": "v0.5.16",
+            "hardware": "fixture-hardware",
+            "workload": {"input_tokens": 2048, "output_tokens": 256, "concurrency": 1},
+            "objective": {
+                "primary": "output_throughput",
+                "direction": "maximize",
+                "minimum_improvement_percent": 3.0,
+            },
+            "hard_limits": {"max_ttft_ms": 500.0, "max_tpot_ms": 5.0},
+            "pareto_metrics": [
+                {"name": "output_throughput", "direction": "maximize"},
+                {"name": "tpot_ms", "direction": "minimize"},
+            ],
+        },
+        "candidates": [
+            {
+                "id": "baseline",
+                "baseline": True,
+                "algorithm": "NONE",
+                "command": ["python3", "-m", "sglang.launch_server", "--model-path", "fixture/model"],
+                "experiment_id": "fixture-search",
+                "status": {"healthy": True, "correct": True, "deterministic": True},
+                "metrics": {
+                    "ttft_ms": 120.0,
+                    "tpot_ms": 4.5,
+                    "output_throughput": 100.0,
+                    "peak_memory_gb": 70.0,
+                },
+                "repeat_count": 3,
+                "artifacts": ["examples/raw/baseline.json"],
+            }
+        ],
+    }
+
+
+class MeasurementValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_valid_document_is_accepted(self) -> None:
+        document = valid_document()
+        self.mod.validate_document(document)
+
+    def test_duplicate_candidate_id_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"].append(dict(document["candidates"][0]))
+        with self.assertRaisesRegex(ValueError, "duplicate candidate id"):
+            self.mod.validate_document(document)
+
+    def test_missing_baseline_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"][0]["baseline"] = False
+        with self.assertRaisesRegex(ValueError, "exactly one baseline"):
+            self.mod.validate_document(document)
+
+    def test_mixed_experiment_identity_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"][0]["experiment_id"] = "other"
+        with self.assertRaisesRegex(ValueError, "experiment_id"):
+            self.mod.validate_document(document)
+```
+
+- [ ] **Step 2: Run the tests and verify the module is missing**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.MeasurementValidationTest -v
+```
+
+Expected: `FileNotFoundError` for `analyze_candidates.py`.
+
+- [ ] **Step 3: Implement strict loading and validation**
+
+Create the script with these public functions and validations:
+
+```python
+#!/usr/bin/env python3
+"""Validate and rank measured SGLang speculative decoding candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shlex
+from pathlib import Path
+from typing import Any
+
+VALID_DIRECTIONS = {"minimize", "maximize"}
+NON_NEGATIVE_METRICS = {
+    "ttft_ms",
+    "tpot_ms",
+    "output_throughput",
+    "request_throughput",
+    "peak_memory_gb",
+    "acceptance_length",
+    "acceptance_rate",
+}
+
+
+def load_document(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("measurement root must be an object")
+    validate_document(value)
+    return value
+
+
+def _finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    return result
+
+
+def validate_document(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("schema_version must be 1")
+    experiment = document.get("experiment")
+    candidates = document.get("candidates")
+    if not isinstance(experiment, dict):
+        raise ValueError("experiment must be an object")
+    if not isinstance(candidates, list) or not candidates:
+        raise ValueError("candidates must be a non-empty array")
+    experiment_id = experiment.get("id")
+    if not isinstance(experiment_id, str) or not experiment_id:
+        raise ValueError("experiment.id must be a non-empty string")
+    ids: set[str] = set()
+    baseline_count = 0
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise ValueError("each candidate must be an object")
+        candidate_id = candidate.get("id")
+        if not isinstance(candidate_id, str) or not candidate_id:
+            raise ValueError("candidate id must be a non-empty string")
+        if candidate_id in ids:
+            raise ValueError(f"duplicate candidate id: {candidate_id}")
+        ids.add(candidate_id)
+        baseline_count += candidate.get("baseline") is True
+        if candidate.get("experiment_id") != experiment_id:
+            raise ValueError(f"{candidate_id}: experiment_id does not match experiment.id")
+        command = candidate.get("command")
+        if not isinstance(command, list) or not command or not all(
+            isinstance(token, str) and token for token in command
+        ):
+            raise ValueError(f"{candidate_id}: command must be a non-empty argv array")
+        status = candidate.get("status")
+        if not isinstance(status, dict):
+            raise ValueError(f"{candidate_id}: status must be an object")
+        metrics = candidate.get("metrics")
+        if not isinstance(metrics, dict):
+            raise ValueError(f"{candidate_id}: metrics must be an object")
+        for name, value in metrics.items():
+            if value is None:
+                continue
+            number = _finite_number(value, f"{candidate_id}.metrics.{name}")
+            if name in NON_NEGATIVE_METRICS and number < 0:
+                raise ValueError(f"{candidate_id}.metrics.{name} must be non-negative")
+    if baseline_count != 1:
+        raise ValueError("candidates must contain exactly one baseline")
+    objective = experiment.get("objective")
+    if not isinstance(objective, dict) or objective.get("direction") not in VALID_DIRECTIONS:
+        raise ValueError("experiment.objective.direction must be minimize or maximize")
+    pareto_metrics = experiment.get("pareto_metrics")
+    if not isinstance(pareto_metrics, list) or not pareto_metrics:
+        raise ValueError("experiment.pareto_metrics must be a non-empty array")
+    for metric in pareto_metrics:
+        if (
+            not isinstance(metric, dict)
+            or not isinstance(metric.get("name"), str)
+            or metric.get("direction") not in VALID_DIRECTIONS
+        ):
+            raise ValueError("each pareto metric needs a name and valid direction")
+```
+
+- [ ] **Step 4: Run the validation tests**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.MeasurementValidationTest -v
+```
+
+Expected: four tests pass.
+
+- [ ] **Step 5: Commit the validated schema boundary**
+
+```bash
+git add tests/test_speculative_decoding_autotuner.py \
+  skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+git commit -m "feat: validate speculative decoding measurements"
+```
+
+### Task 2: Add Hard Gates, Pareto Selection, and Recommendation
+
+**Files:**
+- Modify: `tests/test_speculative_decoding_autotuner.py`
+- Modify: `skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py`
+
+- [ ] **Step 1: Add failing decision tests**
+
+Add candidates with wrong output, an SLA violation, and two valid tradeoffs.
+Assert exact rejection reasons, frontier IDs, and recommendation:
+
+```python
+class CandidateDecisionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_hard_gates_precede_performance_ranking(self) -> None:
+        document = valid_document()
+        wrong = dict(document["candidates"][0])
+        wrong.update(
+            id="wrong-fast",
+            baseline=False,
+            algorithm="DSPARK",
+            status={"healthy": True, "correct": False, "deterministic": True},
+            metrics={"ttft_ms": 80.0, "tpot_ms": 2.0, "output_throughput": 180.0, "peak_memory_gb": 75.0},
+        )
+        slow = dict(document["candidates"][0])
+        slow.update(
+            id="slow-tpot",
+            baseline=False,
+            algorithm="EAGLE",
+            status={"healthy": True, "correct": True, "deterministic": True},
+            metrics={"ttft_ms": 90.0, "tpot_ms": 6.0, "output_throughput": 150.0, "peak_memory_gb": 76.0},
+        )
+        document["candidates"].extend([wrong, slow])
+        result = self.mod.analyze(document)
+        self.assertEqual(result["rejected"]["wrong-fast"], ["correctness_failed"])
+        self.assertEqual(result["rejected"]["slow-tpot"], ["max_tpot_ms_exceeded"])
+
+    def test_pareto_frontier_and_objective_select_safe_winner(self) -> None:
+        document = valid_document()
+        for candidate_id, tpot, throughput in [
+            ("mtp-balanced", 3.9, 118.0),
+            ("dspark-fast", 4.2, 135.0),
+            ("dominated", 4.8, 110.0),
+        ]:
+            candidate = dict(document["candidates"][0])
+            candidate.update(
+                id=candidate_id,
+                baseline=False,
+                algorithm="MTP" if candidate_id == "mtp-balanced" else "DSPARK",
+                status={"healthy": True, "correct": True, "deterministic": True},
+                metrics={"ttft_ms": 100.0, "tpot_ms": tpot, "output_throughput": throughput, "peak_memory_gb": 75.0},
+            )
+            document["candidates"].append(candidate)
+        result = self.mod.analyze(document)
+        self.assertEqual(result["pareto_frontier"], ["dspark-fast", "mtp-balanced"])
+        self.assertEqual(result["recommendation"]["candidate_id"], "dspark-fast")
+        self.assertEqual(result["recommendation"]["status"], "recommended")
+
+    def test_below_noise_threshold_returns_no_safe_improvement(self) -> None:
+        document = valid_document()
+        candidate = dict(document["candidates"][0])
+        candidate.update(
+            id="tiny-gain",
+            baseline=False,
+            algorithm="MTP",
+            status={"healthy": True, "correct": True, "deterministic": True},
+            metrics={"ttft_ms": 110.0, "tpot_ms": 4.4, "output_throughput": 102.0, "peak_memory_gb": 72.0},
+        )
+        document["candidates"].append(candidate)
+        result = self.mod.analyze(document)
+        self.assertEqual(result["recommendation"]["status"], "no_safe_improvement")
+```
+
+- [ ] **Step 2: Run the decision tests and verify missing behavior**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.CandidateDecisionTest -v
+```
+
+Expected: failures because `analyze` is not defined.
+
+- [ ] **Step 3: Implement gates and Pareto dominance**
+
+Add:
+
+```python
+def _gate_reasons(candidate: dict[str, Any], limits: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    status = candidate["status"]
+    for key, reason in [
+        ("healthy", "health_failed"),
+        ("correct", "correctness_failed"),
+        ("deterministic", "determinism_failed"),
+    ]:
+        if status.get(key) is not True:
+            reasons.append(reason)
+    metrics = candidate["metrics"]
+    for limit_name, metric_name, relation in [
+        ("max_ttft_ms", "ttft_ms", "max"),
+        ("max_tpot_ms", "tpot_ms", "max"),
+        ("max_peak_memory_gb", "peak_memory_gb", "max"),
+        ("min_output_throughput", "output_throughput", "min"),
+        ("min_request_throughput", "request_throughput", "min"),
+    ]:
+        if limit_name not in limits:
+            continue
+        if metric_name not in metrics:
+            reasons.append(f"{metric_name}_missing")
+            continue
+        failed = (
+            metrics[metric_name] > limits[limit_name]
+            if relation == "max"
+            else metrics[metric_name] < limits[limit_name]
+        )
+        if failed:
+            reasons.append(f"{limit_name}_exceeded" if relation == "max" else f"{limit_name}_not_met")
+    return reasons
+
+
+def _dominates(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    metric_specs: list[dict[str, str]],
+) -> bool:
+    at_least_as_good = True
+    strictly_better = False
+    for spec in metric_specs:
+        name = spec["name"]
+        if name not in left["metrics"] or name not in right["metrics"]:
+            return False
+        left_value = left["metrics"][name]
+        right_value = right["metrics"][name]
+        if spec["direction"] == "maximize":
+            at_least_as_good &= left_value >= right_value
+            strictly_better |= left_value > right_value
+        else:
+            at_least_as_good &= left_value <= right_value
+            strictly_better |= left_value < right_value
+    return at_least_as_good and strictly_better
+
+
+def pareto_frontier(
+    candidates: list[dict[str, Any]], metric_specs: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    return sorted(
+        [
+            candidate
+            for candidate in candidates
+            if not any(
+                other["id"] != candidate["id"]
+                and _dominates(other, candidate, metric_specs)
+                for other in candidates
+            )
+        ],
+        key=lambda candidate: candidate["id"],
+    )
+```
+
+- [ ] **Step 4: Implement objective ranking and threshold**
+
+Add `analyze(document)` that validates, gates all candidates, excludes the
+baseline from speculative recommendations, requires the primary metric, ranks
+maximize objectives descending and minimize objectives ascending, uses
+candidate ID as the final tie-breaker, and compares the winner with the
+baseline:
+
+```python
+def _improvement_percent(baseline: float, candidate: float, direction: str) -> float:
+    if baseline == 0:
+        return 0.0 if candidate == 0 else math.inf
+    delta = candidate - baseline if direction == "maximize" else baseline - candidate
+    return delta / abs(baseline) * 100.0
+
+
+def analyze(document: dict[str, Any]) -> dict[str, Any]:
+    validate_document(document)
+    experiment = document["experiment"]
+    candidates = document["candidates"]
+    baseline = next(candidate for candidate in candidates if candidate["baseline"])
+    rejected: dict[str, list[str]] = {}
+    accepted: list[dict[str, Any]] = []
+    for candidate in candidates:
+        reasons = _gate_reasons(candidate, experiment.get("hard_limits", {}))
+        if reasons:
+            rejected[candidate["id"]] = reasons
+        else:
+            accepted.append(candidate)
+    speculative = [candidate for candidate in accepted if not candidate["baseline"]]
+    frontier = pareto_frontier(speculative, experiment["pareto_metrics"])
+    objective = experiment["objective"]
+    primary = objective["primary"]
+    rankable = [candidate for candidate in frontier if primary in candidate["metrics"]]
+    if not rankable or baseline["id"] in rejected or primary not in baseline["metrics"]:
+        recommendation = {"status": "no_safe_improvement", "candidate_id": None}
+    else:
+        reverse = objective["direction"] == "maximize"
+        winner = sorted(
+            rankable,
+            key=lambda candidate: (
+                candidate["metrics"][primary] * (-1 if reverse else 1),
+                candidate["id"],
+            ),
+        )[0]
+        improvement = _improvement_percent(
+            baseline["metrics"][primary],
+            winner["metrics"][primary],
+            objective["direction"],
+        )
+        threshold = float(objective.get("minimum_improvement_percent", 0.0))
+        recommendation = {
+            "status": "recommended" if improvement >= threshold else "no_safe_improvement",
+            "candidate_id": winner["id"] if improvement >= threshold else None,
+            "improvement_percent": improvement,
+        }
+    return {
+        "schema_version": 1,
+        "fixture": document.get("fixture") is True,
+        "experiment": experiment,
+        "baseline_id": baseline["id"],
+        "accepted": sorted(candidate["id"] for candidate in accepted),
+        "rejected": rejected,
+        "pareto_frontier": [candidate["id"] for candidate in frontier],
+        "recommendation": recommendation,
+        "candidates": candidates,
+    }
+```
+
+- [ ] **Step 5: Run all decision tests**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+```
+
+Expected: all current tests pass.
+
+- [ ] **Step 6: Commit deterministic selection**
+
+```bash
+git add tests/test_speculative_decoding_autotuner.py \
+  skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+git commit -m "feat: rank safe speculative decoding candidates"
+```
+
+### Task 3: Add Reports and CLI
+
+**Files:**
+- Modify: `tests/test_speculative_decoding_autotuner.py`
+- Modify: `skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py`
+
+- [ ] **Step 1: Write failing report and CLI tests**
+
+Test fixture labeling, rejection reasons, quoted commands, JSON output, and
+non-zero invalid-input behavior:
+
+```python
+class ReportAndCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_markdown_labels_fixture_and_explains_rejections(self) -> None:
+        document = valid_document()
+        result = self.mod.analyze(document)
+        report = self.mod.render_markdown(result)
+        self.assertIn("SYNTHETIC FIXTURE", report)
+        self.assertIn("## Gate Results", report)
+        self.assertIn("## Pareto Frontier", report)
+        self.assertIn("## Recommendation", report)
+        self.assertIn("python3 -m sglang.launch_server", report)
+
+    def test_cli_writes_markdown_and_json(self) -> None:
+        document = valid_document()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            input_path = root / "input.json"
+            markdown_path = root / "report.md"
+            json_path = root / "report.json"
+            input_path.write_text(json.dumps(document), encoding="utf-8")
+            exit_code = self.mod.main(
+                [
+                    "--input",
+                    str(input_path),
+                    "--output-markdown",
+                    str(markdown_path),
+                    "--output-json",
+                    str(json_path),
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("SYNTHETIC FIXTURE", markdown_path.read_text(encoding="utf-8"))
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8"))["schema_version"], 1)
+```
+
+- [ ] **Step 2: Run report tests and verify missing functions**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.ReportAndCliTest -v
+```
+
+Expected: failures for missing `render_markdown` and `main`.
+
+- [ ] **Step 3: Implement Markdown rendering and CLI**
+
+Add a Markdown cell escaper, `shlex.join` command rendering, stable tables, and
+the CLI:
+
+```python
+def _cell(value: Any) -> str:
+    return str(value).replace("\n", "<br>").replace("|", "\\|")
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    lines = ["# SGLang Speculative Decoding Autotuner Report", ""]
+    if result["fixture"]:
+        lines.extend(
+            [
+                "> **SYNTHETIC FIXTURE:** These values demonstrate decision logic; they are not GPU measurements.",
+                "",
+            ]
+        )
+    experiment = result["experiment"]
+    lines.extend(
+        [
+            "## Experiment",
+            "",
+            f"- ID: `{_cell(experiment['id'])}`",
+            f"- Model: `{_cell(experiment['model'])}`",
+            f"- SGLang: `{_cell(experiment['sglang_revision'])}`",
+            f"- Hardware: `{_cell(experiment['hardware'])}`",
+            "",
+            "## Gate Results",
+            "",
+            "| Candidate | Result | Reasons |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for candidate in sorted(result["candidates"], key=lambda item: item["id"]):
+        reasons = result["rejected"].get(candidate["id"], [])
+        lines.append(
+            f"| `{_cell(candidate['id'])}` | {'REJECTED' if reasons else 'ACCEPTED'} | {_cell(', '.join(reasons))} |"
+        )
+    lines.extend(["", "## Pareto Frontier", ""])
+    lines.extend(f"- `{_cell(candidate_id)}`" for candidate_id in result["pareto_frontier"])
+    recommendation = result["recommendation"]
+    lines.extend(
+        [
+            "",
+            "## Recommendation",
+            "",
+            f"- Status: `{recommendation['status']}`",
+            f"- Candidate: `{recommendation.get('candidate_id') or 'none'}`",
+            "",
+            "## Candidate Commands",
+            "",
+        ]
+    )
+    for candidate in sorted(result["candidates"], key=lambda item: item["id"]):
+        lines.extend(
+            [
+                f"### `{_cell(candidate['id'])}`",
+                "",
+                "```bash",
+                shlex.join(candidate["command"]),
+                "```",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate and rank measured SGLang speculative decoding candidates."
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output-markdown", required=True, type=Path)
+    parser.add_argument("--output-json", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        document = load_document(args.input)
+        result = analyze(document)
+        args.output_markdown.write_text(render_markdown(result), encoding="utf-8")
+        args.output_json.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run report and full analyzer tests**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py --help
+```
+
+Expected: all tests pass and CLI help exits zero.
+
+- [ ] **Step 5: Commit reports and CLI**
+
+```bash
+git add tests/test_speculative_decoding_autotuner.py \
+  skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+git commit -m "feat: report speculative decoding recommendations"
+```
+
+### Task 4: Add the Synthetic Demonstration
+
+**Files:**
+- Create: `skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json`
+- Create: `skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md`
+- Modify: `tests/test_speculative_decoding_autotuner.py`
+
+- [ ] **Step 1: Add a failing fixture integration test**
+
+```python
+class FixtureDemoTest(unittest.TestCase):
+    def test_committed_fixture_report_is_reproducible(self) -> None:
+        module = load_module()
+        skill = ROOT / "skills" / "sglang-speculative-decoding-autotuner"
+        document = module.load_document(skill / "examples" / "fixture-measurements.json")
+        result = module.analyze(document)
+        generated = module.render_markdown(result)
+        committed = (skill / "examples" / "fixture-report.md").read_text(encoding="utf-8")
+        self.assertEqual(generated, committed)
+        self.assertEqual(result["recommendation"]["candidate_id"], "dspark-balanced")
+        self.assertEqual(result["rejected"]["dspark-wrong-output"], ["correctness_failed"])
+        self.assertEqual(result["rejected"]["eagle-sla-miss"], ["max_tpot_ms_exceeded"])
+```
+
+- [ ] **Step 2: Run the fixture test and verify files are missing**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.FixtureDemoTest -v
+```
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Create a five-candidate synthetic fixture**
+
+Use the schema from Task 1 with:
+
+```json
+{
+  "schema_version": 1,
+  "fixture": true,
+  "experiment": {
+    "id": "synthetic-v0516-spec-search",
+    "model": "fixture/long-context-moe",
+    "model_revision": "fixture-only",
+    "sglang_revision": "v0.5.16",
+    "hardware": "synthetic-8x-blackwell",
+    "workload": {"input_tokens": 4096, "output_tokens": 512, "concurrency": 8},
+    "objective": {
+      "primary": "output_throughput",
+      "direction": "maximize",
+      "minimum_improvement_percent": 3.0
+    },
+    "hard_limits": {
+      "max_ttft_ms": 400.0,
+      "max_tpot_ms": 4.5,
+      "max_peak_memory_gb": 180.0
+    },
+    "pareto_metrics": [
+      {"name": "output_throughput", "direction": "maximize"},
+      {"name": "tpot_ms", "direction": "minimize"}
+    ]
+  }
+}
+```
+
+Add `baseline`, `dspark-wrong-output`, `eagle-sla-miss`,
+`mtp-low-latency`, and `dspark-balanced`. Give the unsafe candidates the best
+headline throughput so the demo proves gates precede ranking. Set the two safe
+candidates so neither dominates the other and `dspark-balanced` wins the
+maximize-throughput objective.
+
+- [ ] **Step 4: Generate the committed report**
+
+Run:
+
+```bash
+python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
+  --input skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json \
+  --output-markdown skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md \
+  --output-json /tmp/sglang-speculative-decoding-fixture-result.json
+```
+
+Expected: exit zero; report contains the synthetic disclaimer, two rejection
+reasons, two Pareto candidates, and `dspark-balanced`.
+
+- [ ] **Step 5: Run the fixture and analyzer tests**
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit the demo**
+
+```bash
+git add tests/test_speculative_decoding_autotuner.py \
+  skills/sglang-speculative-decoding-autotuner/examples
+git commit -m "test: demonstrate speculative decoding selection"
+```
+
+### Task 5: Write the Skill and References
+
+**Files:**
+- Create: `skills/sglang-speculative-decoding-autotuner/SKILL.md`
+- Create: `skills/sglang-speculative-decoding-autotuner/references/compatibility-and-search.md`
+- Create: `skills/sglang-speculative-decoding-autotuner/references/measurement-schema.md`
+- Modify: `tests/test_speculative_decoding_autotuner.py`
+
+- [ ] **Step 1: Add documentation contract tests**
+
+Assert that the skill frontmatter and safety requirements stay present:
+
+```python
+class SkillDocumentationTest(unittest.TestCase):
+    def test_skill_has_required_contract_and_handoffs(self) -> None:
+        skill = (
+            ROOT / "skills" / "sglang-speculative-decoding-autotuner" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        for required in [
+            "name: sglang-speculative-decoding-autotuner",
+            "non-speculative baseline",
+            "compatibility",
+            "correctness",
+            "Pareto",
+            "no_safe_improvement",
+            "llm-serving-auto-benchmark",
+            "sglang-sota-humanize-loop",
+            "SYNTHETIC FIXTURE",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_references_define_evidence_and_schema(self) -> None:
+        root = ROOT / "skills" / "sglang-speculative-decoding-autotuner"
+        compatibility = (root / "references" / "compatibility-and-search.md").read_text(encoding="utf-8")
+        schema = (root / "references" / "measurement-schema.md").read_text(encoding="utf-8")
+        self.assertIn("selected SGLang revision", compatibility)
+        self.assertIn("bounded", compatibility)
+        self.assertIn("schema_version", schema)
+        self.assertIn("Unknown optional metrics", schema)
+```
+
+- [ ] **Step 2: Run tests and verify missing docs**
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner.SkillDocumentationTest -v
+```
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `SKILL.md`**
+
+Use this frontmatter:
+
+```yaml
+---
+name: sglang-speculative-decoding-autotuner
+description: "Find a safe, workload-specific SGLang speculative decoding configuration by compatibility-gating and benchmarking baseline, MTP/EAGLE, DFlash, DSpark, or other revision-supported candidates. Use for acceptance-length, TTFT/TPOT, throughput, and memory tradeoffs."
+---
+```
+
+The body must define:
+
+- required inputs and a stop-before-launch rule for missing identity;
+- immutable revision and GPU-state capture;
+- authoritative compatibility evidence order;
+- mandatory non-speculative baseline;
+- bounded candidate generation and one-dimension-first search;
+- health, correctness, determinism, memory, and SLA gates;
+- fixed workload/warmup/repeat controls;
+- analyzer invocation and artifact paths;
+- clean-start revalidation of the winner;
+- `no_safe_improvement` as a valid outcome;
+- scoped cleanup;
+- handoff to `llm-serving-auto-benchmark` for general framework comparison and
+  `sglang-sota-humanize-loop` for source changes;
+- exact fixture demo command and synthetic-data warning.
+
+- [ ] **Step 4: Write compatibility and measurement references**
+
+`compatibility-and-search.md` must explain how to inspect the selected SGLang
+revision's CLI, release, source, model config, native MTP/draft availability,
+attention backend, quantization, TP/DP/EP/CP/PD, CUDA Graph, and
+architecture-specific restrictions. Include a bounded-search table and
+candidate stop conditions.
+
+`measurement-schema.md` must document every field accepted in Task 1, required
+metric behavior, metric directions, hard limits, raw artifacts, fixture
+labeling, analyzer outputs, and the fact that unknown optional metrics stay
+unknown.
+
+- [ ] **Step 5: Run documentation tests**
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit the operational skill**
+
+```bash
+git add skills/sglang-speculative-decoding-autotuner/SKILL.md \
+  skills/sglang-speculative-decoding-autotuner/references \
+  tests/test_speculative_decoding_autotuner.py
+git commit -m "docs: add speculative decoding autotuner workflow"
+```
+
+### Task 6: Register the Skill
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `tests/test_repository_metadata.py`
+
+- [ ] **Step 1: Add failing metadata assertions**
+
+Update the hard-coded badge expectation from `core_skills-11` to
+`core_skills-12`, and add:
+
+```python
+def test_speculative_decoding_autotuner_is_registered() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    assert "sglang-speculative-decoding-autotuner" in readme
+    assert "speculative decoding" in plugin["description"].lower()
+    assert "speculative" in marketplace["plugins"][0]["description"].lower()
+```
+
+- [ ] **Step 2: Run metadata tests and verify failure**
+
+```bash
+python3 -m unittest tests.test_repository_metadata -v
+```
+
+Expected: failure because README and plugin metadata are not updated.
+
+- [ ] **Step 3: Update README and plugin metadata**
+
+Add the new skill to:
+
+- the headline capability sentence;
+- the core skill table;
+- per-skill Claude and generic installation commands;
+- the list of invocation examples;
+- the repository map if it enumerates skill directories.
+
+Change the badge to `core_skills-12`. Change the Claude plugin total from 12
+to 13 because the model-history knowledge skill is installed in addition to
+the 12 core skills. Mention speculative decoding tuning in both plugin
+descriptions without changing the published plugin version.
+
+- [ ] **Step 4: Run metadata and analyzer tests**
+
+```bash
+python3 -m unittest tests.test_repository_metadata -v
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit registration**
+
+```bash
+git add README.md .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+  tests/test_repository_metadata.py
+git commit -m "docs: register speculative decoding autotuner"
+```
+
+### Task 7: Validate the Complete Pull Request
+
+**Files:**
+- Modify only when validation exposes an in-scope defect.
+
+- [ ] **Step 1: Regenerate and diff the fixture report**
+
+```bash
+python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
+  --input skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json \
+  --output-markdown /tmp/speculative-decoding-fixture-report.md \
+  --output-json /tmp/speculative-decoding-fixture-result.json
+diff -u skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md \
+  /tmp/speculative-decoding-fixture-report.md
+```
+
+Expected: no diff.
+
+- [ ] **Step 2: Run focused and repository tests**
+
+```bash
+python3 -m unittest tests.test_speculative_decoding_autotuner -v
+python3 -m unittest discover -s tests -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run syntax and repository checks**
+
+```bash
+python3 -m py_compile \
+  skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
+  tests/test_speculative_decoding_autotuner.py
+SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 4: Review scope and claims**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  skills/sglang-speculative-decoding-autotuner README.md \
+  .claude-plugin tests/test_speculative_decoding_autotuner.py \
+  tests/test_repository_metadata.py
+```
+
+Expected: only the planned skill, registration, design, plan, tests, and
+generated fixture report appear. Every fixture value is labeled synthetic and
+there are no universal GPU-performance claims.
+
+- [ ] **Step 5: Commit validation-driven fixes, if any**
+
+```bash
+git status --short
+git add skills/sglang-speculative-decoding-autotuner \
+  tests/test_speculative_decoding_autotuner.py README.md \
+  .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+  tests/test_repository_metadata.py
+git commit -m "test: validate speculative decoding autotuner"
+```
+
+Stage only paths that `git status --short` shows were corrected by validation;
+omit unchanged paths. Skip this commit when validation required no file
+changes.
+
+- [ ] **Step 6: Push and open the draft PR**
+
+```bash
+git push -u origin codex/add-sglang-speculative-decoding-autotuner
+gh pr create --draft --base main \
+  --head codex/add-sglang-speculative-decoding-autotuner \
+  --title "Add SGLang speculative decoding autotuner skill" \
+  --body-file /tmp/sglang-speculative-decoding-autotuner-pr.md
+```
+
+The PR body must contain the user problem, workflow, exact fixture demo command
+and result, test commands, SGLang v0.5.16 evidence scope, synthetic-data
+disclaimer, and non-goals.

--- a/docs/superpowers/specs/2026-07-28-sglang-speculative-decoding-autotuner-design.md
+++ b/docs/superpowers/specs/2026-07-28-sglang-speculative-decoding-autotuner-design.md
@@ -1,0 +1,282 @@
+# SGLang Speculative Decoding Autotuner Design
+
+## Purpose
+
+Add an evidence-driven skill that finds a safe, workload-specific speculative
+decoding configuration for SGLang. The skill will compare a non-speculative
+baseline with only the speculative algorithms that the selected model, SGLang
+revision, hardware, and attention backend can actually support. It will reject
+incorrect or SLA-violating candidates before ranking performance.
+
+The first upstream snapshot is SGLang v0.5.16, whose speculative paths include
+MTP/EAGLE-family modes, DFlash, DSpark, and architecture-specific ReplaySSM
+behavior. The skill must remain version-aware rather than treating the v0.5.16
+flag set as timeless.
+
+## Success Criteria
+
+The pull request is complete when:
+
+1. `sglang-speculative-decoding-autotuner` has an unambiguous trigger and does
+   not overlap with the general `llm-serving-auto-benchmark` or model-patching
+   `sglang-sota-humanize-loop`.
+2. The workflow builds a bounded candidate matrix from proven compatibility
+   evidence instead of blindly trying every speculative flag.
+3. Every candidate is compared with the same model revision, precision,
+   hardware allocation, workload, warmup policy, and correctness prompts.
+4. Correctness, determinism requirements, server health, and SLA constraints
+   are hard gates; throughput alone cannot select a winner.
+5. A deterministic analysis script validates input measurements, reports
+   rejected candidates, computes the Pareto frontier, and recommends a winner
+   using an explicit objective.
+6. The output includes runnable candidate commands, raw measurement references,
+   a result table, a recommendation, and rollback conditions.
+7. Unit tests and a clearly labeled fixture-based demo run without a GPU.
+8. The focused branch is pushed and opened as its own draft pull request
+   against `main`.
+
+## Approaches Considered
+
+### 1. Prompt-only tuning checklist
+
+Document the relevant flags and tell the agent to benchmark them. This is easy
+to maintain, but selection logic and evidence formatting would vary between
+runs, making the claimed recommendation difficult to audit.
+
+### 2. Guided workflow plus deterministic analyzer
+
+Use `SKILL.md` to control discovery, launch, measurement, and stop conditions;
+use a small standard-library Python analyzer for schema validation, hard-gate
+filtering, Pareto analysis, and recommendation; include fixtures and tests.
+
+This is the chosen approach. It makes the changing SGLang compatibility layer a
+documented agent responsibility while keeping the final decision reproducible.
+
+### 3. Fully autonomous server controller
+
+Ship a controller that starts and stops every SGLang configuration and drives
+all benchmarks. This would be convenient on one machine, but would duplicate
+the existing benchmark skill, hard-code cluster assumptions, and make process
+cleanup risky across local, Docker, Slurm, and multi-node environments.
+
+## User Contract
+
+Required inputs:
+
+- model identifier and exact model revision when available;
+- SGLang revision or image;
+- GPU type and count;
+- workload shape, concurrency or request-rate policy, and benchmark duration;
+- optimization objective, such as minimum TPOT under an output-throughput
+  floor;
+- correctness policy and any latency or memory SLA.
+
+Optional inputs:
+
+- allowed or forbidden algorithms;
+- an existing launch command to preserve;
+- draft-model path or model-native MTP availability;
+- attention, quantization, parallelism, or CUDA Graph constraints;
+- a pre-existing measurement JSON file for analysis-only mode.
+
+If required inputs cannot be discovered from the current environment, the
+skill stops before launching candidates and reports the missing fields.
+
+## Architecture and Component Boundaries
+
+### `SKILL.md`
+
+Owns the operational workflow:
+
+1. freeze the experiment contract and record immutable revisions;
+2. inspect SGLang help, model configuration, official docs, release notes, and
+   source to build a compatibility table;
+3. establish a healthy, correct, non-speculative baseline;
+4. generate a bounded candidate set, changing one tuning dimension at a time
+   before combining proven choices;
+5. run identical warmup, correctness, and performance measurements;
+6. write normalized measurements;
+7. invoke the analyzer and interpret the report;
+8. re-run the selected candidate against the baseline;
+9. emit the final recommendation and rollback criteria.
+
+The skill does not patch SGLang source. If evidence points to a kernel or
+scheduler bottleneck rather than a configuration choice, it hands off to the
+existing profiler/SOTA skills with the collected artifact paths.
+
+### Compatibility reference
+
+A concise reference explains how to prove, rather than assume:
+
+- which algorithms exist in the selected SGLang revision;
+- whether the model has a compatible draft model or native MTP layers;
+- restrictions involving attention backends, DP/TP/EP/CP, quantization, CUDA
+  Graphs, top-k, or architecture-specific state;
+- flags and environment variables that changed between releases;
+- which failures require rejecting a candidate rather than lowering its score.
+
+The reference links to upstream evidence but does not copy a permanently frozen
+support matrix that will become stale.
+
+### Candidate and measurement schema
+
+The committed JSON schema is represented by documented examples and enforced by
+the analyzer. Each candidate records:
+
+- stable candidate ID, algorithm, full launch command, and changed parameters;
+- immutable model, framework, hardware, and workload identity;
+- health and correctness outcomes;
+- TTFT, TPOT/ITL, input/output throughput, request throughput, and peak memory
+  when available;
+- speculative metrics such as acceptance length or acceptance rate when
+  exposed;
+- repeat count, aggregate values, raw artifact paths, and failure reason.
+
+Unknown optional metrics remain unknown. They are never coerced to zero.
+
+### Deterministic analyzer
+
+The standard-library Python CLI supports a measurement file and writes
+Markdown plus JSON results. It performs:
+
+1. schema and finite-number validation;
+2. experiment-identity consistency checks;
+3. hard-gate rejection for health, correctness, determinism, memory, and SLA;
+4. Pareto-frontier calculation over explicitly selected minimize/maximize
+   metrics;
+5. objective-based recommendation with deterministic tie-breaking;
+6. baseline-relative deltas;
+7. an explicit no-winner result if no speculative candidate safely improves
+   the baseline.
+
+It never invents missing measurements and never interprets fixture data as a
+real benchmark.
+
+## Data Flow
+
+```text
+model + SGLang revision + hardware + workload/SLA
+                         |
+                         v
+              compatibility evidence
+                         |
+                         v
+        baseline and bounded candidate commands
+                         |
+                         v
+       health -> correctness -> performance runs
+                         |
+                         v
+            normalized measurement JSON
+                         |
+                         v
+      hard gates -> Pareto set -> objective ranking
+                         |
+                         v
+       recommendation + evidence + rollback rules
+```
+
+## Selection and Safety Rules
+
+- The non-speculative baseline is mandatory and cannot be silently replaced by
+  a speculative default.
+- A candidate with wrong output, unhealthy workers, non-finite metrics,
+  excessive memory, or a violated hard SLA is rejected.
+- Algorithm availability is discovered from the selected revision. Current
+  documentation is insufficient evidence for an older installed image.
+- Search budgets cap candidate count and wall time. The skill does not perform
+  an unbounded Cartesian product.
+- Performance claims include exact workload and hardware scope.
+- A small gain below the configured noise threshold is reported as a tie.
+- The winning command is revalidated from a clean server start.
+- Process cleanup targets only PIDs or containers started by the current run.
+
+## Demonstration
+
+The pull request includes a fixture with:
+
+- a valid non-speculative baseline;
+- one speculative candidate that wins on throughput but fails correctness;
+- one candidate that improves throughput but violates the TPOT SLA;
+- two valid candidates with different latency/throughput tradeoffs.
+
+Running the analyzer produces a Markdown report that visibly:
+
+1. rejects the unsafe candidates with reasons;
+2. shows baseline-relative deltas;
+3. identifies the Pareto frontier;
+4. recommends the candidate matching the declared objective;
+5. labels every value as fixture data.
+
+This demonstrates the decision logic on any development machine. It is not
+presented as measured SGLang or GPU performance.
+
+## Error Handling
+
+- Reject malformed JSON, duplicate candidate IDs, mixed experiment identities,
+  missing baselines, non-finite values, invalid metric direction, and negative
+  latency or throughput.
+- Return a non-zero status for invalid evidence, but allow a valid
+  `no_safe_improvement` result when all speculative candidates are rejected or
+  fail to beat the baseline.
+- Preserve raw logs and commands for failed candidates.
+- Do not recommend flags that were not verified against the selected SGLang
+  revision.
+
+## Testing and Validation
+
+Validation includes:
+
+1. unit tests for schema errors, gates, Pareto dominance, objectives,
+   deterministic tie-breaking, and no-winner behavior;
+2. a fixture-demo snapshot with stable Markdown sections;
+3. Python compilation and CLI help checks;
+4. the repository's skill validator and metadata tests;
+5. link and Markdown checks used by the repository;
+6. a staged-diff review for unsupported performance claims and overlap with
+   existing skills.
+
+GPU execution is not required for the pull request because the analyzer and
+workflow can be validated deterministically. Any later real-GPU demonstration
+must report its exact hardware and raw artifacts separately.
+
+## Planned Repository Layout
+
+```text
+skills/sglang-speculative-decoding-autotuner/
+├── SKILL.md
+├── references/
+│   ├── compatibility-and-search.md
+│   └── measurement-schema.md
+├── scripts/
+│   └── analyze_candidates.py
+├── examples/
+│   ├── fixture-measurements.json
+│   └── fixture-report.md
+└── tests/
+    └── test_analyze_candidates.py
+```
+
+The root README, plugin manifest, marketplace metadata, and repository tests
+will be updated only as required to register the new skill.
+
+## Non-Goals
+
+- Implementing a new speculative decoding algorithm.
+- Modifying SGLang kernels, scheduler code, or model weights.
+- Replacing `llm-serving-auto-benchmark` for general framework comparison.
+- Claiming one algorithm is universally best across models or workloads.
+- Managing shared clusters or killing processes not started by the workflow.
+- Treating synthetic fixture values as hardware evidence.
+
+## Commit and Pull Request Strategy
+
+Use focused commits for:
+
+1. this approved design and the implementation plan;
+2. the skill workflow, references, and analyzer;
+3. tests, fixture demo, registration, and validation-driven corrections.
+
+Push `codex/add-sglang-speculative-decoding-autotuner` and open a draft pull
+request against `main`. The pull request will include the exact demo command,
+sample output, test commands, upstream snapshot, and limitations.

--- a/skills/sglang-speculative-decoding-autotuner/SKILL.md
+++ b/skills/sglang-speculative-decoding-autotuner/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: sglang-speculative-decoding-autotuner
+description: "Find a safe, workload-specific SGLang speculative decoding configuration by compatibility-gating and benchmarking a non-speculative baseline against revision-supported MTP/EAGLE, EAGLE3, DFlash, DSpark, NGRAM, or standalone-draft candidates. Use for acceptance-length, TTFT/TPOT, throughput, memory, correctness, and determinism tradeoffs; for deciding whether speculative decoding should be enabled; or for retuning after a model, SGLang, backend, parallelism, quantization, or workload change."
+---
+
+# SGLang Speculative Decoding Autotuner
+
+## Objective
+
+Select a measured configuration, not a fashionable algorithm. Reject unhealthy,
+incorrect, non-deterministic, over-memory, or SLA-violating candidates before
+comparing speed. Return `no_safe_improvement` when speculative decoding does not
+produce a defensible win.
+
+This skill owns a narrow SGLang speculative-decoding search. Use
+`llm-serving-auto-benchmark` for general cross-framework or non-speculative
+serving searches. Hand source or kernel changes to `sglang-sota-humanize-loop`
+after preserving this run's evidence.
+
+## Required Contract
+
+Resolve these fields before launching a server:
+
+| Field | Required evidence |
+| --- | --- |
+| Model | Model ID/path and immutable revision |
+| SGLang | Commit, release tag, or immutable image digest |
+| Hardware | GPU model/count and available topology |
+| Workload | Dataset, input/output lengths, concurrency or request rate, duration |
+| Objective | One primary metric and its direction |
+| Gates | Correctness policy, determinism requirement, memory cap, latency/throughput SLA |
+| Budget | Candidate count, repeats, and wall-clock ceiling |
+
+If any identity field is unknown and cannot be discovered, stop before
+benchmarking. Never compare measurements from different model revisions,
+hardware allocations, workloads, or correctness policies.
+
+## Workflow
+
+### 1. Freeze the experiment
+
+Record:
+
+- full SGLang and model revisions;
+- complete baseline launch command and relevant environment;
+- GPU state before each run;
+- fixed prompts, seeds, sampling parameters, warmup, repeats, and load shape;
+- output artifact directory owned by this run.
+
+Use temperature zero only when the deployment requires it. If determinism is a
+hard requirement, repeat identical requests and record byte/token differences.
+
+### 2. Prove compatibility
+
+Read [compatibility-and-search.md](references/compatibility-and-search.md).
+Inspect the selected SGLang revision's CLI, release notes, source, model config,
+and official cookbook. Do not infer support from newer documentation.
+
+Build a table with:
+
+| Candidate | Proven algorithm/flags | Draft or native MTP evidence | Backend/topology restrictions | Decision |
+| --- | --- | --- | --- | --- |
+
+Exclude unproven candidates. Record the source URL or local source path for
+every included algorithm and fragile flag.
+
+### 3. Establish the non-speculative baseline
+
+Launch without speculative decoding. Require:
+
+1. healthy workers and endpoint readiness;
+2. expected outputs on the fixed correctness set;
+3. required determinism;
+4. warmup completion;
+5. repeated benchmark measurements;
+6. complete command, logs, and raw result paths.
+
+Stop if the baseline is unhealthy or violates correctness. A speculative result
+cannot repair an invalid baseline.
+
+### 4. Search within a hard budget
+
+Start from defaults proven for the selected revision. Change one dimension at a
+time before combining winners:
+
+1. algorithm or draft source;
+2. draft steps/window/block size;
+3. top-k/tree width;
+4. draft-token count;
+5. compatible attention/verify mode;
+6. only then safe combinations.
+
+Keep the model, precision, topology, workload, and SLA fixed. Cap candidate
+count and wall time. Stop an algorithm family after repeated health,
+correctness, determinism, memory, or clear performance failures.
+
+### 5. Measure every candidate identically
+
+For each clean server start:
+
+1. capture the exact argv and environment;
+2. verify health;
+3. run correctness and determinism gates;
+4. run identical warmup and repeats;
+5. collect TTFT, TPOT/ITL, request and token throughput, peak memory, and
+   acceptance metrics when exposed;
+6. retain raw logs and benchmark results;
+7. stop only the PID/container created for this candidate.
+
+Reuse the workload runner from `llm-serving-auto-benchmark` when helpful, but
+do not allow it to change the experiment contract.
+
+### 6. Normalize and analyze
+
+Read [measurement-schema.md](references/measurement-schema.md), then write one
+measurement document. Run:
+
+```bash
+python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
+  --input /path/to/speculative-measurements.json \
+  --output-markdown /path/to/speculative-report.md \
+  --output-json /path/to/speculative-result.json
+```
+
+The analyzer validates identities and metrics, applies health/correctness/
+determinism/SLA gates, constructs the Pareto frontier, and ranks the primary
+objective. Do not manually override a rejection to obtain a winner.
+
+### 7. Revalidate and report
+
+Restart the recommended command from a clean, run-owned process and repeat the
+baseline contract. Report:
+
+- exact winner and baseline commands;
+- accepted/rejected candidates with reasons;
+- metric table and baseline deltas;
+- Pareto frontier and primary objective;
+- correctness, determinism, SLA, and memory evidence;
+- raw artifact paths;
+- compatibility sources;
+- rollback conditions.
+
+If the analyzer returns `no_safe_improvement`, keep the baseline and state why.
+
+## Safety Rules
+
+- Never run an unbounded Cartesian search.
+- Never treat acceptance length alone as a performance or correctness result.
+- Never compare different workloads or GPU allocations in one decision.
+- Never present fixture values as hardware evidence.
+- Never kill shared processes or clear shared model caches.
+- Never patch SGLang within this skill.
+- Re-run compatibility discovery after any SGLang, model, quantization,
+  attention-backend, parallelism, or draft-model change.
+
+## Demonstration
+
+Run the committed decision-logic example:
+
+```bash
+python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
+  --input skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json \
+  --output-markdown /tmp/speculative-fixture-report.md \
+  --output-json /tmp/speculative-fixture-result.json
+```
+
+The generated report starts with **SYNTHETIC FIXTURE**. It demonstrates that a
+fast wrong-output candidate and an SLA miss are rejected before the safe Pareto
+set is ranked. It is not a GPU benchmark.
+
+## Resources
+
+- [compatibility-and-search.md](references/compatibility-and-search.md): read
+  before authoring candidates or after any revision/configuration change.
+- [measurement-schema.md](references/measurement-schema.md): read before
+  writing analyzer input or integrating a benchmark harness.
+- `scripts/analyze_candidates.py`: deterministic validation and selection.
+- `examples/fixture-report.md`: expected demonstration output.

--- a/skills/sglang-speculative-decoding-autotuner/agents/openai.yaml
+++ b/skills/sglang-speculative-decoding-autotuner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang Speculative Decoding Autotuner"
+  short_description: "Tune safe speculative decoding configs"
+  default_prompt: "Use $sglang-speculative-decoding-autotuner to find the safest, fastest speculative decoding configuration for this SGLang workload."

--- a/skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json
+++ b/skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 1,
+  "fixture": true,
+  "experiment": {
+    "id": "synthetic-v0516-spec-search",
+    "model": "fixture/long-context-moe",
+    "model_revision": "fixture-only",
+    "sglang_revision": "v0.5.16",
+    "hardware": "synthetic-8x-blackwell",
+    "workload": {
+      "input_tokens": 4096,
+      "output_tokens": 512,
+      "concurrency": 8
+    },
+    "objective": {
+      "primary": "output_throughput",
+      "direction": "maximize",
+      "minimum_improvement_percent": 3.0
+    },
+    "hard_limits": {
+      "max_ttft_ms": 400.0,
+      "max_tpot_ms": 4.5,
+      "max_peak_memory_gb": 180.0
+    },
+    "pareto_metrics": [
+      {
+        "name": "output_throughput",
+        "direction": "maximize"
+      },
+      {
+        "name": "tpot_ms",
+        "direction": "minimize"
+      }
+    ]
+  },
+  "candidates": [
+    {
+      "id": "baseline",
+      "baseline": true,
+      "algorithm": "NONE",
+      "command": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/long-context-moe",
+        "--tp",
+        "8"
+      ],
+      "experiment_id": "synthetic-v0516-spec-search",
+      "status": {
+        "healthy": true,
+        "correct": true,
+        "deterministic": true
+      },
+      "metrics": {
+        "ttft_ms": 160.0,
+        "tpot_ms": 4.4,
+        "output_throughput": 100.0,
+        "request_throughput": 1.2,
+        "peak_memory_gb": 145.0,
+        "acceptance_length": null
+      },
+      "repeat_count": 3,
+      "artifacts": [
+        "synthetic/raw/baseline.json"
+      ]
+    },
+    {
+      "id": "dspark-wrong-output",
+      "baseline": false,
+      "algorithm": "DSPARK",
+      "command": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/long-context-moe",
+        "--tp",
+        "8",
+        "--speculative-algorithm",
+        "DSPARK",
+        "--speculative-dspark-block-size",
+        "8"
+      ],
+      "experiment_id": "synthetic-v0516-spec-search",
+      "status": {
+        "healthy": true,
+        "correct": false,
+        "deterministic": true
+      },
+      "metrics": {
+        "ttft_ms": 105.0,
+        "tpot_ms": 2.8,
+        "output_throughput": 155.0,
+        "request_throughput": 1.8,
+        "peak_memory_gb": 153.0,
+        "acceptance_length": 5.4
+      },
+      "repeat_count": 3,
+      "artifacts": [
+        "synthetic/raw/dspark-wrong-output.json"
+      ]
+    },
+    {
+      "id": "eagle-sla-miss",
+      "baseline": false,
+      "algorithm": "EAGLE3",
+      "command": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/long-context-moe",
+        "--tp",
+        "8",
+        "--speculative-algorithm",
+        "EAGLE3",
+        "--speculative-draft-model-path",
+        "fixture/eagle3-draft",
+        "--speculative-num-steps",
+        "5",
+        "--speculative-eagle-topk",
+        "8",
+        "--speculative-num-draft-tokens",
+        "64"
+      ],
+      "experiment_id": "synthetic-v0516-spec-search",
+      "status": {
+        "healthy": true,
+        "correct": true,
+        "deterministic": true
+      },
+      "metrics": {
+        "ttft_ms": 115.0,
+        "tpot_ms": 5.1,
+        "output_throughput": 142.0,
+        "request_throughput": 1.7,
+        "peak_memory_gb": 158.0,
+        "acceptance_length": 4.8
+      },
+      "repeat_count": 3,
+      "artifacts": [
+        "synthetic/raw/eagle-sla-miss.json"
+      ]
+    },
+    {
+      "id": "mtp-low-latency",
+      "baseline": false,
+      "algorithm": "MTP",
+      "command": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/long-context-moe",
+        "--tp",
+        "8",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "3",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "4"
+      ],
+      "experiment_id": "synthetic-v0516-spec-search",
+      "status": {
+        "healthy": true,
+        "correct": true,
+        "deterministic": true
+      },
+      "metrics": {
+        "ttft_ms": 118.0,
+        "tpot_ms": 3.4,
+        "output_throughput": 122.0,
+        "request_throughput": 1.45,
+        "peak_memory_gb": 149.0,
+        "acceptance_length": 3.1
+      },
+      "repeat_count": 3,
+      "artifacts": [
+        "synthetic/raw/mtp-low-latency.json"
+      ]
+    },
+    {
+      "id": "dspark-balanced",
+      "baseline": false,
+      "algorithm": "DSPARK",
+      "command": [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        "fixture/long-context-moe",
+        "--tp",
+        "8",
+        "--speculative-algorithm",
+        "DSPARK",
+        "--speculative-dspark-block-size",
+        "4"
+      ],
+      "experiment_id": "synthetic-v0516-spec-search",
+      "status": {
+        "healthy": true,
+        "correct": true,
+        "deterministic": true
+      },
+      "metrics": {
+        "ttft_ms": 125.0,
+        "tpot_ms": 3.8,
+        "output_throughput": 138.0,
+        "request_throughput": 1.65,
+        "peak_memory_gb": 151.0,
+        "acceptance_length": 4.6
+      },
+      "repeat_count": 3,
+      "artifacts": [
+        "synthetic/raw/dspark-balanced.json"
+      ]
+    }
+  ]
+}

--- a/skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md
+++ b/skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md
@@ -1,0 +1,96 @@
+# SGLang Speculative Decoding Autotuner Report
+
+> **SYNTHETIC FIXTURE:** These values demonstrate decision logic; they are not GPU measurements.
+
+## Experiment
+
+- ID: `synthetic-v0516-spec-search`
+- Model: `fixture/long-context-moe` at `fixture-only`
+- SGLang: `v0.5.16`
+- Hardware: `synthetic-8x-blackwell`
+- Objective: `maximize output_throughput`
+- Minimum improvement: `3.00%`
+
+## Gate Results
+
+| Candidate | Algorithm | Result | Reasons |
+| --- | --- | --- | --- |
+| `baseline` | `NONE` | ACCEPTED | none |
+| `dspark-balanced` | `DSPARK` | ACCEPTED | none |
+| `dspark-wrong-output` | `DSPARK` | REJECTED | correctness_failed |
+| `eagle-sla-miss` | `EAGLE3` | REJECTED | max_tpot_ms_exceeded |
+| `mtp-low-latency` | `MTP` | ACCEPTED | none |
+
+## Metrics and Baseline Deltas
+
+| Candidate | TTFT ms | Δ TTFT | TPOT ms | Δ TPOT | Output tok/s | Δ Output tok/s | Peak GiB | Accept length |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `baseline` | 160.00 | +0.00 | 4.40 | +0.00 | 100.00 | +0.00 | 145.00 | unknown |
+| `dspark-balanced` | 125.00 | -35.00 | 3.80 | -0.60 | 138.00 | +38.00 | 151.00 | 4.60 |
+| `dspark-wrong-output` | 105.00 | -55.00 | 2.80 | -1.60 | 155.00 | +55.00 | 153.00 | 5.40 |
+| `eagle-sla-miss` | 115.00 | -45.00 | 5.10 | +0.70 | 142.00 | +42.00 | 158.00 | 4.80 |
+| `mtp-low-latency` | 118.00 | -42.00 | 3.40 | -1.00 | 122.00 | +22.00 | 149.00 | 3.10 |
+
+## Pareto Frontier
+
+- `dspark-balanced`
+- `mtp-low-latency`
+
+## Recommendation
+
+- Status: `recommended`
+- Candidate: `dspark-balanced`
+- Primary-metric improvement: `38.00%`
+
+## Candidate Commands
+
+### `baseline`
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/long-context-moe --tp 8
+```
+
+Artifacts:
+- `synthetic/raw/baseline.json`
+
+### `dspark-balanced`
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/long-context-moe --tp 8 --speculative-algorithm DSPARK --speculative-dspark-block-size 4
+```
+
+Artifacts:
+- `synthetic/raw/dspark-balanced.json`
+
+### `dspark-wrong-output`
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/long-context-moe --tp 8 --speculative-algorithm DSPARK --speculative-dspark-block-size 8
+```
+
+Artifacts:
+- `synthetic/raw/dspark-wrong-output.json`
+
+### `eagle-sla-miss`
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/long-context-moe --tp 8 --speculative-algorithm EAGLE3 --speculative-draft-model-path fixture/eagle3-draft --speculative-num-steps 5 --speculative-eagle-topk 8 --speculative-num-draft-tokens 64
+```
+
+Artifacts:
+- `synthetic/raw/eagle-sla-miss.json`
+
+### `mtp-low-latency`
+
+```bash
+python3 -m sglang.launch_server --model-path fixture/long-context-moe --tp 8 --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
+```
+
+Artifacts:
+- `synthetic/raw/mtp-low-latency.json`
+
+## Revalidation and Rollback
+
+- Restart the selected candidate from a clean, run-owned server process and repeat the baseline contract.
+- Roll back to the recorded baseline command if health, correctness, determinism, memory, or latency gates fail.
+- Treat `no_safe_improvement` as a successful audit outcome; do not force-enable speculative decoding.

--- a/skills/sglang-speculative-decoding-autotuner/references/compatibility-and-search.md
+++ b/skills/sglang-speculative-decoding-autotuner/references/compatibility-and-search.md
@@ -1,0 +1,146 @@
+# Compatibility Proof and Bounded Search
+
+## Contents
+
+- [Evidence order](#evidence-order)
+- [Compatibility record](#compatibility-record)
+- [Algorithm checks](#algorithm-checks)
+- [Search order](#search-order)
+- [Stop conditions](#stop-conditions)
+- [SGLang v0.5.16 example evidence](#sglang-v0516-example-evidence)
+
+## Evidence order
+
+Prove compatibility against the **selected SGLang revision** in this order:
+
+1. `python -m sglang.launch_server --help` from the installed environment.
+2. The exact release/tag and its upgrade or known-issue notes.
+3. `server_args.py`, speculative algorithm enums, model runner, attention
+   backend, and tests at the exact commit.
+4. The model's immutable config and draft/MTP checkpoint contents.
+5. Official cookbook commands scoped to the same release.
+
+Current main-branch documentation can suggest what to inspect, but it does not
+prove an older image supports a flag or combination.
+
+Record the command or URL beside each conclusion. Mark a candidate `unknown`
+and exclude it when evidence conflicts or remains incomplete.
+
+## Compatibility record
+
+Capture at least:
+
+```text
+candidate_id:
+algorithm:
+sglang_revision:
+algorithm_symbol_or_cli_source:
+target_model_revision:
+draft_model_or_native_mtp_evidence:
+attention_backend:
+verify_mode:
+quantization:
+tp_pp_dp_ep_cp_pd:
+cuda_graph_mode:
+required_environment:
+known_restrictions:
+decision: include | exclude
+reason:
+```
+
+Check both startup compatibility and semantic compatibility. A server that
+accepts flags may still use an incompatible draft tokenizer, head, hidden size,
+MTP layer layout, state cache, or verify backend.
+
+## Algorithm checks
+
+For every algorithm family, verify:
+
+- the algorithm value exists in the selected CLI/source;
+- a required draft checkpoint exists and matches the target model;
+- native MTP weights and layer counts are present when claimed;
+- target and draft tokenizers/vocabularies meet upstream requirements;
+- attention prefill/decode/verify backends support the path;
+- TP, PP, DP attention, EP, CP, PD disaggregation, and overlap scheduling are
+  supported in the exact combination;
+- quantization supports both target and draft paths;
+- CUDA Graph capture supports the chosen steps, top-k, and draft-token shapes;
+- architecture-specific recurrent or linear-attention state restrictions are
+  satisfied;
+- required environment variables are recorded with the candidate command.
+
+Treat an upstream assertion scoped to one model or GPU as scoped evidence, not
+a universal capability.
+
+## Search order
+
+Use a bounded, staged search:
+
+| Stage | Change | Keep fixed | Advance when |
+| --- | --- | --- | --- |
+| Baseline | No speculative decoding | Everything else | Healthy and correct |
+| Family | One proven algorithm/draft source | Workload and serving topology | At least one safe improvement |
+| Shape | Steps/window/block size | Algorithm and backend | Stable gain exceeds noise |
+| Width | Top-k/tree/draft tokens | Best safe shape | Correctness and memory pass |
+| Backend | Proven compatible verify/attention mode | Best safe algorithm parameters | Gain survives clean restart |
+| Combine | Previously winning choices only | Experiment contract | Revalidation passes |
+
+Set explicit ceilings for:
+
+- total candidates;
+- candidates per family;
+- startup failures;
+- correctness failures;
+- repeated regressions;
+- wall-clock time;
+- disk usage for artifacts.
+
+When an interface offers an automatic parameter mode, benchmark that mode as
+one candidate. Do not mix partially explicit flag groups when upstream requires
+all related values to be either automatic or explicit.
+
+## Stop conditions
+
+Reject a candidate immediately for:
+
+- worker crash, hang, or unhealthy endpoint;
+- correctness mismatch;
+- determinism failure when determinism is required;
+- incompatible tokenizer/draft/MTP state;
+- non-finite measurement;
+- memory cap or hard SLA failure.
+
+Stop exploring an algorithm family after the configured consecutive failure
+budget or after multiple candidates are clearly dominated outside the noise
+threshold. Preserve its logs and reason.
+
+Return `no_safe_improvement` when:
+
+- all speculative candidates are rejected;
+- no candidate beats the baseline by the declared minimum improvement;
+- the apparent gain falls inside measurement noise;
+- compatibility remains unproven.
+
+## SGLang v0.5.16 example evidence
+
+Use these only as an example of source collection. Re-resolve them for the
+requested version:
+
+- [v0.5.16 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.16)
+  documents DSpark, ReplaySSM Ring Spec-Verify, backend changes, and known
+  issues.
+- [Speculative decoding documentation](https://docs.sglang.io/docs/advanced_features/speculative_decoding)
+  describes EAGLE/EAGLE3, DFlash, standalone, NGRAM, MTP-related parameters,
+  and tuning groups.
+- [DSpark implementation PR #30261](https://github.com/sgl-project/sglang/pull/30261)
+  is direct evidence for the confidence-scheduled algorithm.
+- [ReplaySSM PR #28695](https://github.com/sgl-project/sglang/pull/28695)
+  documents architecture-specific state and top-k restrictions.
+- [v0.5.16 tag source](https://github.com/sgl-project/sglang/tree/v0.5.16)
+  is the immutable implementation snapshot.
+
+For DSpark in v0.5.16, the release notes name
+`--speculative-algorithm DSPARK`,
+`--speculative-dspark-block-size`, and
+`SGLANG_RAGGED_VERIFY_MODE=compact`. Verify those names again for any other
+revision.

--- a/skills/sglang-speculative-decoding-autotuner/references/measurement-schema.md
+++ b/skills/sglang-speculative-decoding-autotuner/references/measurement-schema.md
@@ -1,0 +1,165 @@
+# Measurement and Result Schema
+
+## Contents
+
+- [Input root](#input-root)
+- [Experiment](#experiment)
+- [Candidate](#candidate)
+- [Hard gates](#hard-gates)
+- [Selection](#selection)
+- [Analyzer output](#analyzer-output)
+- [Unknown values and fixtures](#unknown-values-and-fixtures)
+
+## Input root
+
+Provide one JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "fixture": false,
+  "experiment": {},
+  "candidates": []
+}
+```
+
+`fixture` is required only for examples. Set it to `true` for synthetic data;
+the Markdown report will display a prominent warning.
+
+## Experiment
+
+Required fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `id` | string | Stable experiment identity copied to every candidate |
+| `model` | string | Model ID or path |
+| `model_revision` | string | Immutable revision or digest |
+| `sglang_revision` | string | Commit, tag, or immutable image |
+| `hardware` | string | Exact GPU allocation/topology label |
+| `workload` | object | Fixed load shape and dataset identity |
+| `objective` | object | Primary metric, direction, and noise threshold |
+| `hard_limits` | object | Required latency, throughput, and memory gates |
+| `pareto_metrics` | array | Metrics and directions used for dominance |
+
+Example objective:
+
+```json
+{
+  "primary": "output_throughput",
+  "direction": "maximize",
+  "minimum_improvement_percent": 3.0
+}
+```
+
+Directions are `maximize` or `minimize`.
+
+Supported hard-limit keys:
+
+| Limit | Metric | Behavior |
+| --- | --- | --- |
+| `max_ttft_ms` | `ttft_ms` | Reject above |
+| `max_tpot_ms` | `tpot_ms` | Reject above |
+| `max_peak_memory_gb` | `peak_memory_gb` | Reject above |
+| `min_output_throughput` | `output_throughput` | Reject below |
+| `min_request_throughput` | `request_throughput` | Reject below |
+
+A metric referenced by an active hard limit, the objective, or the speculative
+Pareto set is required for that candidate.
+
+## Candidate
+
+Each candidate has:
+
+```json
+{
+  "id": "dspark-block-4",
+  "baseline": false,
+  "algorithm": "DSPARK",
+  "command": ["python3", "-m", "sglang.launch_server"],
+  "experiment_id": "experiment-1",
+  "status": {
+    "healthy": true,
+    "correct": true,
+    "deterministic": true
+  },
+  "metrics": {
+    "ttft_ms": 125.0,
+    "tpot_ms": 3.8,
+    "output_throughput": 138.0,
+    "request_throughput": 1.65,
+    "peak_memory_gb": 151.0,
+    "acceptance_length": 4.6,
+    "acceptance_rate": null
+  },
+  "repeat_count": 3,
+  "artifacts": ["runs/dspark-block-4/result.json"]
+}
+```
+
+Rules:
+
+- Supply exactly one candidate with `baseline: true`.
+- Represent commands as argv arrays, not shell strings.
+- Copy the root experiment ID exactly.
+- Set every status field from recorded evidence.
+- Store aggregate metrics from the declared repeat policy.
+- Keep raw artifacts addressable from the final report.
+- Do not encode missing values as zero.
+
+## Hard gates
+
+The analyzer rejects in this order:
+
+1. health;
+2. correctness;
+3. determinism;
+4. active hard limits;
+5. missing objective or Pareto metrics.
+
+Rejection reasons remain in JSON and Markdown. Rejected candidates still appear
+in the metric table for diagnosis but cannot join the Pareto frontier or win.
+
+## Selection
+
+The analyzer:
+
+1. validates one shared experiment identity;
+2. gates every candidate;
+3. excludes the baseline from speculative candidates;
+4. calculates Pareto dominance using the declared directions;
+5. ranks frontier candidates by the primary objective;
+6. breaks exact ties by candidate ID for deterministic output;
+7. compares the winner with the baseline;
+8. returns `no_safe_improvement` below the declared threshold.
+
+Baseline deltas are candidate minus baseline. Therefore a negative TTFT/TPOT
+delta is normally favorable, while a positive throughput delta is favorable.
+
+## Analyzer output
+
+The JSON result contains:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Result schema version |
+| `fixture` | Whether input was synthetic |
+| `experiment` | Frozen experiment contract |
+| `baseline_id` | Baseline candidate |
+| `accepted` | IDs that passed hard gates |
+| `rejected` | ID to ordered rejection reasons |
+| `pareto_frontier` | Safe non-baseline frontier IDs |
+| `recommendation` | Status, candidate, improvement percentage |
+| `evaluations` | Metrics, deltas, commands, repeats, and artifacts |
+
+The Markdown report presents the same information plus revalidation and
+rollback guidance.
+
+## Unknown values and fixtures
+
+Unknown optional metrics remain `null` or are omitted. They are never converted
+to zero. Metrics used by a gate or selection rule are not optional.
+
+Set `fixture: true` for invented values used to test or demonstrate the
+analyzer. The report must retain the **SYNTHETIC FIXTURE** warning. Never cite a
+fixture report as SGLang, model, algorithm, or GPU performance evidence.

--- a/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+++ b/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 VALID_DIRECTIONS = {"minimize", "maximize"}
 NON_NEGATIVE_METRICS = {
     "ttft_ms",
@@ -71,14 +70,10 @@ def validate_document(document: dict[str, Any]) -> None:
         _require_string(experiment.get(field), f"experiment.{field}")
     _require_mapping(experiment.get("workload"), "experiment.workload")
 
-    objective = _require_mapping(
-        experiment.get("objective"), "experiment.objective"
-    )
+    objective = _require_mapping(experiment.get("objective"), "experiment.objective")
     _require_string(objective.get("primary"), "experiment.objective.primary")
     if objective.get("direction") not in VALID_DIRECTIONS:
-        raise ValueError(
-            "experiment.objective.direction must be minimize or maximize"
-        )
+        raise ValueError("experiment.objective.direction must be minimize or maximize")
     if "minimum_improvement_percent" in objective:
         threshold = _finite_number(
             objective["minimum_improvement_percent"],
@@ -150,9 +145,7 @@ def validate_document(document: dict[str, Any]) -> None:
                 continue
             number = _finite_number(value, f"{candidate_id}.metrics.{name}")
             if name in NON_NEGATIVE_METRICS and number < 0:
-                raise ValueError(
-                    f"{candidate_id}.metrics.{name} must be non-negative"
-                )
+                raise ValueError(f"{candidate_id}.metrics.{name} must be non-negative")
         repeat_count = candidate.get("repeat_count")
         if not isinstance(repeat_count, int) or isinstance(repeat_count, bool):
             raise ValueError(f"{candidate_id}.repeat_count must be an integer")
@@ -320,9 +313,11 @@ def analyze(document: dict[str, Any]) -> dict[str, Any]:
         winner = sorted(
             frontier,
             key=lambda candidate: (
-                -float(candidate["metrics"][primary])
-                if direction == "maximize"
-                else float(candidate["metrics"][primary]),
+                (
+                    -float(candidate["metrics"][primary])
+                    if direction == "maximize"
+                    else float(candidate["metrics"][primary])
+                ),
                 candidate["id"],
             ),
         )[0]
@@ -457,8 +452,7 @@ def render_markdown(result: dict[str, Any]) -> str:
     lines.extend(["", "## Pareto Frontier", ""])
     if result["pareto_frontier"]:
         lines.extend(
-            f"- `{_cell(candidate_id)}`"
-            for candidate_id in result["pareto_frontier"]
+            f"- `{_cell(candidate_id)}`" for candidate_id in result["pareto_frontier"]
         )
     else:
         lines.append("- No safe speculative candidate reached the frontier.")
@@ -471,10 +465,8 @@ def render_markdown(result: dict[str, Any]) -> str:
             "## Recommendation",
             "",
             f"- Status: `{_cell(recommendation['status'])}`",
-            f"- Candidate: "
-            f"`{_cell(recommendation.get('candidate_id') or 'none')}`",
-            f"- Primary-metric improvement: "
-            f"`{_metric(improvement)}%`",
+            f"- Candidate: " f"`{_cell(recommendation.get('candidate_id') or 'none')}`",
+            f"- Primary-metric improvement: " f"`{_metric(improvement)}%`",
             "",
             "## Candidate Commands",
             "",

--- a/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+++ b/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
@@ -166,3 +166,204 @@ def validate_document(document: dict[str, Any]) -> None:
 
     if baseline_count != 1:
         raise ValueError("candidates must contain exactly one baseline")
+
+
+def _gate_reasons(
+    candidate: dict[str, Any],
+    experiment: dict[str, Any],
+) -> list[str]:
+    reasons: list[str] = []
+    status = candidate["status"]
+    for field, reason in (
+        ("healthy", "health_failed"),
+        ("correct", "correctness_failed"),
+        ("deterministic", "determinism_failed"),
+    ):
+        if status[field] is not True:
+            reasons.append(reason)
+
+    metrics = candidate["metrics"]
+    for limit_name, (metric_name, direction) in LIMITS.items():
+        if limit_name not in experiment["hard_limits"]:
+            continue
+        if metrics.get(metric_name) is None:
+            reasons.append(f"hard_limit_metric_missing:{metric_name}")
+            continue
+        limit = float(experiment["hard_limits"][limit_name])
+        value = float(metrics[metric_name])
+        failed = value > limit if direction == "max" else value < limit
+        if failed:
+            reasons.append(
+                f"{limit_name}_exceeded"
+                if direction == "max"
+                else f"{limit_name}_not_met"
+            )
+
+    primary = experiment["objective"]["primary"]
+    if metrics.get(primary) is None:
+        reasons.append(f"objective_metric_missing:{primary}")
+
+    if candidate["baseline"] is not True:
+        for spec in experiment["pareto_metrics"]:
+            metric_name = spec["name"]
+            if metrics.get(metric_name) is None:
+                reasons.append(f"pareto_metric_missing:{metric_name}")
+
+    return reasons
+
+
+def _dominates(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    metric_specs: list[dict[str, str]],
+) -> bool:
+    at_least_as_good = True
+    strictly_better = False
+    for spec in metric_specs:
+        metric_name = spec["name"]
+        left_value = float(left["metrics"][metric_name])
+        right_value = float(right["metrics"][metric_name])
+        if spec["direction"] == "maximize":
+            if left_value < right_value:
+                at_least_as_good = False
+            if left_value > right_value:
+                strictly_better = True
+        else:
+            if left_value > right_value:
+                at_least_as_good = False
+            if left_value < right_value:
+                strictly_better = True
+    return at_least_as_good and strictly_better
+
+
+def pareto_frontier(
+    candidates: list[dict[str, Any]],
+    metric_specs: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    frontier = [
+        candidate
+        for candidate in candidates
+        if not any(
+            other["id"] != candidate["id"]
+            and _dominates(other, candidate, metric_specs)
+            for other in candidates
+        )
+    ]
+    return sorted(frontier, key=lambda candidate: candidate["id"])
+
+
+def _improvement_percent(
+    baseline: float,
+    candidate: float,
+    direction: str,
+) -> float:
+    if baseline == 0:
+        if candidate == 0:
+            return 0.0
+        favorable = candidate > 0 if direction == "maximize" else candidate < 0
+        return math.inf if favorable else -math.inf
+    favorable_delta = (
+        candidate - baseline if direction == "maximize" else baseline - candidate
+    )
+    return favorable_delta / abs(baseline) * 100.0
+
+
+def _metric_deltas(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+) -> dict[str, float]:
+    deltas: dict[str, float] = {}
+    for name, baseline_value in baseline["metrics"].items():
+        candidate_value = candidate["metrics"].get(name)
+        if baseline_value is None or candidate_value is None:
+            continue
+        if isinstance(baseline_value, bool) or isinstance(candidate_value, bool):
+            continue
+        if not isinstance(baseline_value, (int, float)) or not isinstance(
+            candidate_value, (int, float)
+        ):
+            continue
+        deltas[name] = float(candidate_value) - float(baseline_value)
+    return deltas
+
+
+def analyze(document: dict[str, Any]) -> dict[str, Any]:
+    validate_document(document)
+    experiment = document["experiment"]
+    candidates = document["candidates"]
+    baseline = next(candidate for candidate in candidates if candidate["baseline"])
+
+    rejected: dict[str, list[str]] = {}
+    accepted: list[dict[str, Any]] = []
+    for candidate in candidates:
+        reasons = _gate_reasons(candidate, experiment)
+        if reasons:
+            rejected[candidate["id"]] = reasons
+        else:
+            accepted.append(candidate)
+
+    speculative = [
+        candidate for candidate in accepted if candidate["baseline"] is not True
+    ]
+    frontier = pareto_frontier(speculative, experiment["pareto_metrics"])
+    objective = experiment["objective"]
+    primary = objective["primary"]
+
+    if baseline["id"] in rejected or not frontier:
+        recommendation: dict[str, Any] = {
+            "status": "no_safe_improvement",
+            "candidate_id": None,
+            "improvement_percent": None,
+        }
+    else:
+        direction = objective["direction"]
+        winner = sorted(
+            frontier,
+            key=lambda candidate: (
+                -float(candidate["metrics"][primary])
+                if direction == "maximize"
+                else float(candidate["metrics"][primary]),
+                candidate["id"],
+            ),
+        )[0]
+        improvement = _improvement_percent(
+            float(baseline["metrics"][primary]),
+            float(winner["metrics"][primary]),
+            direction,
+        )
+        threshold = float(objective.get("minimum_improvement_percent", 0.0))
+        is_recommended = improvement >= threshold
+        recommendation = {
+            "status": "recommended" if is_recommended else "no_safe_improvement",
+            "candidate_id": winner["id"] if is_recommended else None,
+            "improvement_percent": improvement,
+        }
+
+    evaluations = []
+    for candidate in sorted(candidates, key=lambda item: item["id"]):
+        evaluations.append(
+            {
+                "id": candidate["id"],
+                "baseline": candidate["baseline"],
+                "algorithm": candidate["algorithm"],
+                "accepted": candidate["id"] not in rejected,
+                "reasons": rejected.get(candidate["id"], []),
+                "metrics": candidate["metrics"],
+                "baseline_deltas": _metric_deltas(baseline, candidate),
+                "command": candidate["command"],
+                "repeat_count": candidate["repeat_count"],
+                "artifacts": candidate["artifacts"],
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "fixture": document.get("fixture") is True,
+        "experiment": experiment,
+        "baseline_id": baseline["id"],
+        "accepted": sorted(candidate["id"] for candidate in accepted),
+        "rejected": rejected,
+        "pareto_frontier": [candidate["id"] for candidate in frontier],
+        "recommendation": recommendation,
+        "evaluations": evaluations,
+    }

--- a/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+++ b/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate and rank measured SGLang speculative decoding candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VALID_DIRECTIONS = {"minimize", "maximize"}
+NON_NEGATIVE_METRICS = {
+    "ttft_ms",
+    "tpot_ms",
+    "output_throughput",
+    "request_throughput",
+    "peak_memory_gb",
+    "acceptance_length",
+    "acceptance_rate",
+}
+STATUS_FIELDS = ("healthy", "correct", "deterministic")
+LIMITS = {
+    "max_ttft_ms": ("ttft_ms", "max"),
+    "max_tpot_ms": ("tpot_ms", "max"),
+    "max_peak_memory_gb": ("peak_memory_gb", "max"),
+    "min_output_throughput": ("output_throughput", "min"),
+    "min_request_throughput": ("request_throughput", "min"),
+}
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    return result
+
+
+def load_document(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("measurement root must be an object")
+    validate_document(value)
+    return value
+
+
+def validate_document(document: dict[str, Any]) -> None:
+    if document.get("schema_version") != 1:
+        raise ValueError("schema_version must be 1")
+
+    experiment = _require_mapping(document.get("experiment"), "experiment")
+    experiment_id = _require_string(experiment.get("id"), "experiment.id")
+    for field in ("model", "model_revision", "sglang_revision", "hardware"):
+        _require_string(experiment.get(field), f"experiment.{field}")
+    _require_mapping(experiment.get("workload"), "experiment.workload")
+
+    objective = _require_mapping(
+        experiment.get("objective"), "experiment.objective"
+    )
+    _require_string(objective.get("primary"), "experiment.objective.primary")
+    if objective.get("direction") not in VALID_DIRECTIONS:
+        raise ValueError(
+            "experiment.objective.direction must be minimize or maximize"
+        )
+    if "minimum_improvement_percent" in objective:
+        threshold = _finite_number(
+            objective["minimum_improvement_percent"],
+            "experiment.objective.minimum_improvement_percent",
+        )
+        if threshold < 0:
+            raise ValueError(
+                "experiment.objective.minimum_improvement_percent must be non-negative"
+            )
+
+    limits = experiment.get("hard_limits", {})
+    _require_mapping(limits, "experiment.hard_limits")
+    for name, value in limits.items():
+        if name not in LIMITS:
+            raise ValueError(f"unknown hard limit: {name}")
+        if _finite_number(value, f"experiment.hard_limits.{name}") < 0:
+            raise ValueError(f"experiment.hard_limits.{name} must be non-negative")
+
+    pareto_metrics = experiment.get("pareto_metrics")
+    if not isinstance(pareto_metrics, list) or not pareto_metrics:
+        raise ValueError("experiment.pareto_metrics must be a non-empty array")
+    pareto_names: set[str] = set()
+    for index, metric in enumerate(pareto_metrics):
+        spec = _require_mapping(metric, f"experiment.pareto_metrics[{index}]")
+        name = _require_string(spec.get("name"), f"pareto metric {index}.name")
+        if name in pareto_names:
+            raise ValueError(f"duplicate pareto metric: {name}")
+        pareto_names.add(name)
+        if spec.get("direction") not in VALID_DIRECTIONS:
+            raise ValueError(
+                f"pareto metric {name} direction must be minimize or maximize"
+            )
+
+    candidates = document.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ValueError("candidates must be a non-empty array")
+
+    candidate_ids: set[str] = set()
+    baseline_count = 0
+    for index, candidate_value in enumerate(candidates):
+        candidate = _require_mapping(candidate_value, f"candidate {index}")
+        candidate_id = _require_string(candidate.get("id"), f"candidate {index}.id")
+        if candidate_id in candidate_ids:
+            raise ValueError(f"duplicate candidate id: {candidate_id}")
+        candidate_ids.add(candidate_id)
+        if candidate.get("baseline") is True:
+            baseline_count += 1
+        elif candidate.get("baseline") is not False:
+            raise ValueError(f"{candidate_id}: baseline must be true or false")
+        _require_string(candidate.get("algorithm"), f"{candidate_id}.algorithm")
+        if candidate.get("experiment_id") != experiment_id:
+            raise ValueError(
+                f"{candidate_id}: experiment_id does not match experiment.id"
+            )
+        command = candidate.get("command")
+        if (
+            not isinstance(command, list)
+            or not command
+            or not all(isinstance(token, str) and token for token in command)
+        ):
+            raise ValueError(f"{candidate_id}: command must be a non-empty argv array")
+        status = _require_mapping(candidate.get("status"), f"{candidate_id}.status")
+        for field in STATUS_FIELDS:
+            if not isinstance(status.get(field), bool):
+                raise ValueError(f"{candidate_id}.status.{field} must be boolean")
+        metrics = _require_mapping(candidate.get("metrics"), f"{candidate_id}.metrics")
+        for name, value in metrics.items():
+            if value is None:
+                continue
+            number = _finite_number(value, f"{candidate_id}.metrics.{name}")
+            if name in NON_NEGATIVE_METRICS and number < 0:
+                raise ValueError(
+                    f"{candidate_id}.metrics.{name} must be non-negative"
+                )
+        repeat_count = candidate.get("repeat_count")
+        if not isinstance(repeat_count, int) or isinstance(repeat_count, bool):
+            raise ValueError(f"{candidate_id}.repeat_count must be an integer")
+        if repeat_count < 1:
+            raise ValueError(f"{candidate_id}.repeat_count must be positive")
+        artifacts = candidate.get("artifacts")
+        if not isinstance(artifacts, list) or not all(
+            isinstance(item, str) and item for item in artifacts
+        ):
+            raise ValueError(f"{candidate_id}.artifacts must be a string array")
+
+    if baseline_count != 1:
+        raise ValueError("candidates must contain exactly one baseline")

--- a/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
+++ b/skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py
@@ -367,3 +367,182 @@ def analyze(document: dict[str, Any]) -> dict[str, Any]:
         "recommendation": recommendation,
         "evaluations": evaluations,
     }
+
+
+def _cell(value: Any) -> str:
+    return str(value).replace("\n", "<br>").replace("|", "\\|")
+
+
+def _metric(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _delta(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return f"{float(value):+.2f}"
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    experiment = result["experiment"]
+    lines = ["# SGLang Speculative Decoding Autotuner Report", ""]
+    if result["fixture"]:
+        lines.extend(
+            [
+                "> **SYNTHETIC FIXTURE:** These values demonstrate decision "
+                "logic; they are not GPU measurements.",
+                "",
+            ]
+        )
+
+    objective = experiment["objective"]
+    lines.extend(
+        [
+            "## Experiment",
+            "",
+            f"- ID: `{_cell(experiment['id'])}`",
+            f"- Model: `{_cell(experiment['model'])}` at "
+            f"`{_cell(experiment['model_revision'])}`",
+            f"- SGLang: `{_cell(experiment['sglang_revision'])}`",
+            f"- Hardware: `{_cell(experiment['hardware'])}`",
+            f"- Objective: `{_cell(objective['direction'])} "
+            f"{_cell(objective['primary'])}`",
+            f"- Minimum improvement: "
+            f"`{float(objective.get('minimum_improvement_percent', 0.0)):.2f}%`",
+            "",
+            "## Gate Results",
+            "",
+            "| Candidate | Algorithm | Result | Reasons |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for evaluation in result["evaluations"]:
+        reasons = ", ".join(evaluation["reasons"])
+        lines.append(
+            f"| `{_cell(evaluation['id'])}` | "
+            f"`{_cell(evaluation['algorithm'])}` | "
+            f"{'ACCEPTED' if evaluation['accepted'] else 'REJECTED'} | "
+            f"{_cell(reasons or 'none')} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Metrics and Baseline Deltas",
+            "",
+            "| Candidate | TTFT ms | Δ TTFT | TPOT ms | Δ TPOT | "
+            "Output tok/s | Δ Output tok/s | Peak GiB | Accept length |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for evaluation in result["evaluations"]:
+        metrics = evaluation["metrics"]
+        deltas = evaluation["baseline_deltas"]
+        lines.append(
+            f"| `{_cell(evaluation['id'])}` | "
+            f"{_metric(metrics.get('ttft_ms'))} | "
+            f"{_delta(deltas.get('ttft_ms'))} | "
+            f"{_metric(metrics.get('tpot_ms'))} | "
+            f"{_delta(deltas.get('tpot_ms'))} | "
+            f"{_metric(metrics.get('output_throughput'))} | "
+            f"{_delta(deltas.get('output_throughput'))} | "
+            f"{_metric(metrics.get('peak_memory_gb'))} | "
+            f"{_metric(metrics.get('acceptance_length'))} |"
+        )
+
+    lines.extend(["", "## Pareto Frontier", ""])
+    if result["pareto_frontier"]:
+        lines.extend(
+            f"- `{_cell(candidate_id)}`"
+            for candidate_id in result["pareto_frontier"]
+        )
+    else:
+        lines.append("- No safe speculative candidate reached the frontier.")
+
+    recommendation = result["recommendation"]
+    improvement = recommendation.get("improvement_percent")
+    lines.extend(
+        [
+            "",
+            "## Recommendation",
+            "",
+            f"- Status: `{_cell(recommendation['status'])}`",
+            f"- Candidate: "
+            f"`{_cell(recommendation.get('candidate_id') or 'none')}`",
+            f"- Primary-metric improvement: "
+            f"`{_metric(improvement)}%`",
+            "",
+            "## Candidate Commands",
+            "",
+        ]
+    )
+    for evaluation in result["evaluations"]:
+        lines.extend(
+            [
+                f"### `{_cell(evaluation['id'])}`",
+                "",
+                "```bash",
+                shlex.join(evaluation["command"]),
+                "```",
+                "",
+                "Artifacts:",
+            ]
+        )
+        if evaluation["artifacts"]:
+            lines.extend(
+                f"- `{_cell(artifact)}`" for artifact in evaluation["artifacts"]
+            )
+        else:
+            lines.append("- none")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Revalidation and Rollback",
+            "",
+            "- Restart the selected candidate from a clean, run-owned server "
+            "process and repeat the baseline contract.",
+            "- Roll back to the recorded baseline command if health, correctness, "
+            "determinism, memory, or latency gates fail.",
+            "- Treat `no_safe_improvement` as a successful audit outcome; do not "
+            "force-enable speculative decoding.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate and rank measured SGLang speculative decoding candidates."
+        )
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output-markdown", required=True, type=Path)
+    parser.add_argument("--output-json", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        document = load_document(args.input)
+        result = analyze(document)
+        args.output_markdown.write_text(render_markdown(result), encoding="utf-8")
+        args.output_json.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_model_pr_dossier_quality.py
+++ b/tests/test_model_pr_dossier_quality.py
@@ -202,7 +202,7 @@ def test_readme_installs_model_pr_diff_dossier_skill() -> None:
     assert "[`model-pr-diff-dossier`]" in readme
     assert f'ln -s "$PWD/{skill_path}" ~/.claude/skills/model-pr-diff-dossier' in readme
     assert f"cp -R {skill_path} <agent-skill-dir>/model-pr-diff-dossier" in readme
-    assert "After reload, the 12 skills appear" in readme
+    assert "After reload, the 13 skills appear" in readme
 
 
 def test_rebuild_history_dry_run_does_not_update_indexes(tmp_path) -> None:

--- a/tests/test_repository_metadata.py
+++ b/tests/test_repository_metadata.py
@@ -16,7 +16,7 @@ def test_readme_uses_current_claude_and_codex_launch_commands() -> None:
     assert "codex --yolo" not in readme
     assert "`opus`" in readme and "current Opus" in readme
     assert "bypassPermissions" in readme and "isolated" in readme
-    assert "core_skills-11" in readme
+    assert "core_skills-12" in readme
 
 
 def test_marketplace_has_top_level_description() -> None:
@@ -27,6 +27,20 @@ def test_marketplace_has_top_level_description() -> None:
     assert marketplace["description"]
     assert "LLM serving" in marketplace["description"]
     assert marketplace["plugins"][0]["description"]
+
+
+def test_speculative_decoding_autotuner_is_registered() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+
+    assert "sglang-speculative-decoding-autotuner" in readme
+    assert "speculative decoding" in plugin["description"].lower()
+    assert "speculative" in marketplace["plugins"][0]["description"].lower()
 
 
 def test_precommit_versions_are_current_verified_tags() -> None:

--- a/tests/test_speculative_decoding_autotuner.py
+++ b/tests/test_speculative_decoding_autotuner.py
@@ -369,5 +369,33 @@ class ReportAndCliTest(unittest.TestCase):
             self.assertEqual(exit_code, 2)
 
 
+class FixtureDemoTest(unittest.TestCase):
+    def test_committed_fixture_report_is_reproducible(self) -> None:
+        module = load_module()
+        document = module.load_document(
+            SKILL_ROOT / "examples" / "fixture-measurements.json"
+        )
+
+        result = module.analyze(document)
+        generated = module.render_markdown(result)
+        committed = (
+            SKILL_ROOT / "examples" / "fixture-report.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(generated, committed)
+        self.assertEqual(
+            result["recommendation"]["candidate_id"], "dspark-balanced"
+        )
+        self.assertEqual(
+            result["rejected"]["dspark-wrong-output"], ["correctness_failed"]
+        )
+        self.assertEqual(
+            result["rejected"]["eagle-sla-miss"], ["max_tpot_ms_exceeded"]
+        )
+        self.assertEqual(
+            result["pareto_frontier"], ["dspark-balanced", "mtp-low-latency"]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_speculative_decoding_autotuner.py
+++ b/tests/test_speculative_decoding_autotuner.py
@@ -397,5 +397,45 @@ class FixtureDemoTest(unittest.TestCase):
         )
 
 
+class SkillDocumentationTest(unittest.TestCase):
+    def test_skill_has_required_contract_and_handoffs(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+        for required in [
+            "name: sglang-speculative-decoding-autotuner",
+            "non-speculative baseline",
+            "compatibility",
+            "correctness",
+            "Pareto",
+            "no_safe_improvement",
+            "llm-serving-auto-benchmark",
+            "sglang-sota-humanize-loop",
+            "SYNTHETIC FIXTURE",
+        ]:
+            self.assertIn(required, skill)
+        self.assertNotIn("TODO", skill)
+
+    def test_references_define_evidence_and_schema(self) -> None:
+        compatibility = (
+            SKILL_ROOT / "references" / "compatibility-and-search.md"
+        ).read_text(encoding="utf-8")
+        schema = (
+            SKILL_ROOT / "references" / "measurement-schema.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("selected SGLang revision", compatibility)
+        self.assertIn("bounded", compatibility)
+        self.assertIn("schema_version", schema)
+        self.assertIn("Unknown optional metrics", schema)
+
+    def test_openai_metadata_mentions_the_skill(self) -> None:
+        metadata = (SKILL_ROOT / "agents" / "openai.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("SGLang Speculative Decoding Autotuner", metadata)
+        self.assertIn("$sglang-speculative-decoding-autotuner", metadata)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_speculative_decoding_autotuner.py
+++ b/tests/test_speculative_decoding_autotuner.py
@@ -160,5 +160,119 @@ class MeasurementValidationTest(unittest.TestCase):
             self.mod.validate_document(document)
 
 
+class CandidateDecisionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_hard_gates_precede_performance_ranking(self) -> None:
+        document = valid_document()
+        add_candidate(
+            document,
+            candidate_id="wrong-fast",
+            algorithm="DSPARK",
+            ttft_ms=80.0,
+            tpot_ms=2.0,
+            output_throughput=180.0,
+            correct=False,
+        )
+        add_candidate(
+            document,
+            candidate_id="slow-tpot",
+            algorithm="EAGLE",
+            ttft_ms=90.0,
+            tpot_ms=6.0,
+            output_throughput=150.0,
+        )
+
+        result = self.mod.analyze(document)
+
+        self.assertEqual(result["rejected"]["wrong-fast"], ["correctness_failed"])
+        self.assertEqual(
+            result["rejected"]["slow-tpot"], ["max_tpot_ms_exceeded"]
+        )
+        self.assertEqual(result["recommendation"]["status"], "no_safe_improvement")
+
+    def test_pareto_frontier_and_objective_select_safe_winner(self) -> None:
+        document = valid_document()
+        add_candidate(
+            document,
+            candidate_id="mtp-low-latency",
+            algorithm="MTP",
+            ttft_ms=95.0,
+            tpot_ms=3.7,
+            output_throughput=118.0,
+        )
+        add_candidate(
+            document,
+            candidate_id="dspark-balanced",
+            algorithm="DSPARK",
+            ttft_ms=100.0,
+            tpot_ms=4.1,
+            output_throughput=135.0,
+        )
+        add_candidate(
+            document,
+            candidate_id="dominated",
+            algorithm="EAGLE",
+            ttft_ms=110.0,
+            tpot_ms=4.8,
+            output_throughput=110.0,
+        )
+
+        result = self.mod.analyze(document)
+
+        self.assertEqual(
+            result["pareto_frontier"], ["dspark-balanced", "mtp-low-latency"]
+        )
+        self.assertEqual(
+            result["recommendation"]["candidate_id"], "dspark-balanced"
+        )
+        self.assertEqual(result["recommendation"]["status"], "recommended")
+        self.assertAlmostEqual(
+            result["recommendation"]["improvement_percent"], 35.0
+        )
+
+    def test_below_noise_threshold_returns_no_safe_improvement(self) -> None:
+        document = valid_document()
+        add_candidate(
+            document,
+            candidate_id="tiny-gain",
+            algorithm="MTP",
+            ttft_ms=110.0,
+            tpot_ms=4.4,
+            output_throughput=102.0,
+        )
+
+        result = self.mod.analyze(document)
+
+        self.assertEqual(
+            result["recommendation"]["status"], "no_safe_improvement"
+        )
+        self.assertIsNone(result["recommendation"]["candidate_id"])
+        self.assertAlmostEqual(result["recommendation"]["improvement_percent"], 2.0)
+
+    def test_missing_selection_metric_is_rejected(self) -> None:
+        document = valid_document()
+        candidate = add_candidate(
+            document,
+            candidate_id="missing-tpot",
+            algorithm="MTP",
+            ttft_ms=90.0,
+            tpot_ms=4.0,
+            output_throughput=120.0,
+        )
+        del candidate["metrics"]["tpot_ms"]
+
+        result = self.mod.analyze(document)
+
+        self.assertEqual(
+            result["rejected"]["missing-tpot"],
+            [
+                "hard_limit_metric_missing:tpot_ms",
+                "pareto_metric_missing:tpot_ms",
+            ],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_speculative_decoding_autotuner.py
+++ b/tests/test_speculative_decoding_autotuner.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills" / "sglang-speculative-decoding-autotuner"
+SCRIPT = SKILL_ROOT / "scripts" / "analyze_candidates.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("spec_autotuner", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_document() -> dict:
+    return {
+        "schema_version": 1,
+        "fixture": True,
+        "experiment": {
+            "id": "fixture-search",
+            "model": "fixture/model",
+            "model_revision": "fixture-revision",
+            "sglang_revision": "v0.5.16",
+            "hardware": "fixture-hardware",
+            "workload": {
+                "input_tokens": 2048,
+                "output_tokens": 256,
+                "concurrency": 1,
+            },
+            "objective": {
+                "primary": "output_throughput",
+                "direction": "maximize",
+                "minimum_improvement_percent": 3.0,
+            },
+            "hard_limits": {
+                "max_ttft_ms": 500.0,
+                "max_tpot_ms": 5.0,
+                "max_peak_memory_gb": 80.0,
+            },
+            "pareto_metrics": [
+                {"name": "output_throughput", "direction": "maximize"},
+                {"name": "tpot_ms", "direction": "minimize"},
+            ],
+        },
+        "candidates": [
+            {
+                "id": "baseline",
+                "baseline": True,
+                "algorithm": "NONE",
+                "command": [
+                    "python3",
+                    "-m",
+                    "sglang.launch_server",
+                    "--model-path",
+                    "fixture/model",
+                ],
+                "experiment_id": "fixture-search",
+                "status": {
+                    "healthy": True,
+                    "correct": True,
+                    "deterministic": True,
+                },
+                "metrics": {
+                    "ttft_ms": 120.0,
+                    "tpot_ms": 4.5,
+                    "output_throughput": 100.0,
+                    "peak_memory_gb": 70.0,
+                    "acceptance_length": None,
+                },
+                "repeat_count": 3,
+                "artifacts": ["examples/raw/baseline.json"],
+            }
+        ],
+    }
+
+
+def add_candidate(
+    document: dict,
+    *,
+    candidate_id: str,
+    algorithm: str,
+    ttft_ms: float,
+    tpot_ms: float,
+    output_throughput: float,
+    peak_memory_gb: float = 75.0,
+    healthy: bool = True,
+    correct: bool = True,
+    deterministic: bool = True,
+) -> dict:
+    candidate = copy.deepcopy(document["candidates"][0])
+    candidate.update(
+        {
+            "id": candidate_id,
+            "baseline": False,
+            "algorithm": algorithm,
+            "status": {
+                "healthy": healthy,
+                "correct": correct,
+                "deterministic": deterministic,
+            },
+            "metrics": {
+                "ttft_ms": ttft_ms,
+                "tpot_ms": tpot_ms,
+                "output_throughput": output_throughput,
+                "peak_memory_gb": peak_memory_gb,
+                "acceptance_length": 4.0,
+            },
+        }
+    )
+    document["candidates"].append(candidate)
+    return candidate
+
+
+class MeasurementValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_valid_document_is_accepted(self) -> None:
+        self.mod.validate_document(valid_document())
+
+    def test_duplicate_candidate_id_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"].append(copy.deepcopy(document["candidates"][0]))
+
+        with self.assertRaisesRegex(ValueError, "duplicate candidate id"):
+            self.mod.validate_document(document)
+
+    def test_missing_baseline_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"][0]["baseline"] = False
+
+        with self.assertRaisesRegex(ValueError, "exactly one baseline"):
+            self.mod.validate_document(document)
+
+    def test_mixed_experiment_identity_is_rejected(self) -> None:
+        document = valid_document()
+        document["candidates"][0]["experiment_id"] = "other"
+
+        with self.assertRaisesRegex(ValueError, "experiment_id"):
+            self.mod.validate_document(document)
+
+    def test_non_finite_metric_is_rejected_but_unknown_optional_metric_is_allowed(
+        self,
+    ) -> None:
+        document = valid_document()
+        self.mod.validate_document(document)
+        document["candidates"][0]["metrics"]["ttft_ms"] = math.inf
+
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            self.mod.validate_document(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speculative_decoding_autotuner.py
+++ b/tests/test_speculative_decoding_autotuner.py
@@ -274,5 +274,100 @@ class CandidateDecisionTest(unittest.TestCase):
         )
 
 
+class ReportAndCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_markdown_labels_fixture_and_explains_decision(self) -> None:
+        document = valid_document()
+        add_candidate(
+            document,
+            candidate_id="wrong-fast",
+            algorithm="DSPARK",
+            ttft_ms=80.0,
+            tpot_ms=2.0,
+            output_throughput=180.0,
+            correct=False,
+        )
+        add_candidate(
+            document,
+            candidate_id="mtp-safe",
+            algorithm="MTP",
+            ttft_ms=100.0,
+            tpot_ms=3.8,
+            output_throughput=125.0,
+        )
+
+        report = self.mod.render_markdown(self.mod.analyze(document))
+
+        self.assertIn("SYNTHETIC FIXTURE", report)
+        self.assertIn("## Gate Results", report)
+        self.assertIn("correctness_failed", report)
+        self.assertIn("## Metrics and Baseline Deltas", report)
+        self.assertIn("+25.00", report)
+        self.assertIn("## Pareto Frontier", report)
+        self.assertIn("## Recommendation", report)
+        self.assertIn("`mtp-safe`", report)
+        self.assertIn("python3 -m sglang.launch_server", report)
+        self.assertIn("examples/raw/baseline.json", report)
+
+    def test_cli_writes_markdown_and_json(self) -> None:
+        document = valid_document()
+        add_candidate(
+            document,
+            candidate_id="mtp-safe",
+            algorithm="MTP",
+            ttft_ms=100.0,
+            tpot_ms=3.8,
+            output_throughput=125.0,
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            input_path = root / "input.json"
+            markdown_path = root / "report.md"
+            json_path = root / "report.json"
+            input_path.write_text(json.dumps(document), encoding="utf-8")
+
+            exit_code = self.mod.main(
+                [
+                    "--input",
+                    str(input_path),
+                    "--output-markdown",
+                    str(markdown_path),
+                    "--output-json",
+                    str(json_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn(
+                "SYNTHETIC FIXTURE", markdown_path.read_text(encoding="utf-8")
+            )
+            result = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(result["schema_version"], 1)
+            self.assertEqual(
+                result["recommendation"]["candidate_id"], "mtp-safe"
+            )
+
+    def test_cli_returns_two_for_invalid_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            input_path = root / "input.json"
+            input_path.write_text("[]", encoding="utf-8")
+
+            exit_code = self.mod.main(
+                [
+                    "--input",
+                    str(input_path),
+                    "--output-markdown",
+                    str(root / "report.md"),
+                    "--output-json",
+                    str(root / "report.json"),
+                ]
+            )
+
+            self.assertEqual(exit_code, 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add `sglang-speculative-decoding-autotuner`, a measurement-driven workflow for choosing among baseline, EAGLE, MTP, and DSpark configurations
- validate benchmark artifacts before ranking, reject candidates that fail health/correctness/determinism/SLA/memory gates, and compute a Pareto frontier
- emit both Markdown and JSON recommendations with baseline deltas, exact commands, evidence paths, and rejection reasons
- include a deterministic synthetic fixture, unit tests, design notes, and an implementation plan
- register the skill in the repository README, plugin manifests, and metadata tests

## Why

SGLang now exposes several speculative decoding paths, but the best mode and parameters depend on the model, workload, hardware, and latency constraints. This skill turns that choice into a reproducible search-and-decision workflow instead of relying on a single default or intuition.

## Demo

```bash
python3 skills/sglang-speculative-decoding-autotuner/scripts/analyze_candidates.py \
  --input skills/sglang-speculative-decoding-autotuner/examples/fixture-measurements.json \
  --output-markdown /tmp/speculative-report.md \
  --output-json /tmp/speculative-report.json
```

The included synthetic fixture:

- rejects `dspark-wrong-output` because correctness fails
- rejects `eagle-sla-miss` because TPOT exceeds the configured SLA
- places `dspark-balanced` and `mtp-low-latency` on the Pareto frontier
- recommends `dspark-balanced`, which shows a synthetic 38% output-throughput improvement over baseline

The checked-in report is available at [fixture-report.md](../blob/codex/add-sglang-speculative-decoding-autotuner/skills/sglang-speculative-decoding-autotuner/examples/fixture-report.md).

## Safety and limits

The analyzer never launches or stops servers and never treats synthetic data as measured performance. It consumes explicit benchmark artifacts, keeps commands as inert argv arrays, and returns `no_safe_improvement` when no candidate clears the configured threshold.

## Validation

- `python3 -m pytest -q`: 187 passed
- `pre-commit run --all-files --show-diff-on-failure`: passed
- skill-creator `quick_validate.py`: passed
- fixture report regeneration is deterministic
