### PR TITLE
Link diffusion optimization patches to SGLang quality profiles

### DIFF
--- a/sgl-engine-sglang-diffusion/README.md
+++ b/sgl-engine-sglang-diffusion/README.md
@@ -334,5 +334,6 @@ environment and are redacted from receipts. Preserve campaign evidence and
 clean only campaign-owned processes and temporary paths.
 
 When the packaged SGLang change exposes an optimization profile, its runtime
-entry remains `--agent-optimization off|auto|<profile-id>`. Here “agent”
-labels the generated profile namespace; it does not launch another AI process.
+entry is `--quality off|auto|<profile-id>`. The validated manifest lives under
+`sglang.multimodal_gen.quality_profiles.profiles`; generated kernels may remain
+model-scoped under `sglang.kernels.agent`.

--- a/sgl-engine-sglang-diffusion/contracts/sglang/placement-and-registration.md
+++ b/sgl-engine-sglang-diffusion/contracts/sglang/placement-and-registration.md
@@ -65,9 +65,9 @@ its declarations, extension registration, build entries, and canonical
 The final patch exposes:
 
 ```text
---agent-optimization off
---agent-optimization auto
---agent-optimization <profile-id>
+--quality off
+--quality auto
+--quality <profile-id>
 ```
 
 `off` is identical to the locked native source. `auto` activates only an exact

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/patcher.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/patcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import shlex
@@ -18,6 +19,16 @@ from .process import run
 
 _MODEL_SLUG = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_VBENCH_DIMENSIONS = frozenset(
+    {
+        "subject_consistency",
+        "background_consistency",
+        "motion_smoothness",
+        "temporal_flickering",
+        "aesthetic_quality",
+        "imaging_quality",
+    }
+)
 _FORBIDDEN_CONTENT = (
     re.compile(r"/Users/"),
     re.compile(r"/home/[^/\s]+/"),
@@ -168,11 +179,24 @@ class PatchPackager:
             raise PatchError(
                 "agent profile was not built from the requested SGLang base SHA"
             )
+        if profile.server_args.get("quality") != profile.profile_id:
+            raise PatchError(
+                "agent profile must activate through "
+                f"--quality {profile.profile_id}"
+            )
+        quality_profile_path = self._require_file(
+            "python/sglang/multimodal_gen/quality_profiles/profiles/"
+            f"{profile.profile_id}.json"
+        )
+        self._validate_quality_profile(
+            json.loads(quality_profile_path.read_text(encoding="utf-8")),
+            profile=profile,
+        )
         diff = run(
             ["git", "diff", "--binary", "--full-index", f"{self.base_sha}..HEAD"],
             cwd=self.worktree,
         ).stdout
-        for required_literal in ("--agent-optimization", "off", "auto"):
+        for required_literal in ("--quality", "off", "auto"):
             if required_literal not in diff:
                 raise PatchError(
                     f"SGLang diff is missing runtime option literal "
@@ -233,6 +257,11 @@ class PatchPackager:
             "profile_sha256": sha256_file(
                 self.worktree
                 / f"python/sglang/kernels/agent/diffusion/{model_slug}/manifest.json"
+            ),
+            "quality_profile_sha256": sha256_file(
+                self.worktree
+                / "python/sglang/multimodal_gen/quality_profiles/profiles"
+                / f"{profile.profile_id}.json"
             ),
             "patch_sha256": sha256_file(patch_path),
             "evidence": copied_evidence,
@@ -424,6 +453,72 @@ class PatchPackager:
             or not _SHA256.fullmatch(digest)
         ):
             raise PatchError("derived checkpoint immutable metadata is invalid")
+
+    @staticmethod
+    def _validate_quality_profile(
+        payload: Mapping[str, Any], *, profile: AgentProfile
+    ) -> None:
+        if payload.get("schema_version") != 1:
+            raise PatchError("SGLang quality profile schema_version must be 1")
+        if payload.get("profile_id") != profile.profile_id:
+            raise PatchError("SGLang quality profile ID does not match agent profile")
+        if payload.get("status") != "validated":
+            raise PatchError("SGLang quality profile must have status='validated'")
+        model_ids = payload.get("model_ids")
+        if (
+            not isinstance(model_ids, list)
+            or not set(model_ids).intersection(profile.model_ids)
+        ):
+            raise PatchError("SGLang quality profile model IDs do not match")
+        evidence = payload.get("evidence")
+        if not isinstance(evidence, dict):
+            raise PatchError("SGLang quality profile evidence is missing")
+        if (
+            evidence.get("prompt_count") != 5
+            or evidence.get("visual_overall") != "pass"
+            or evidence.get("native_backend") is not True
+            or evidence.get("fallback_count") != 0
+        ):
+            raise PatchError(
+                "SGLang quality profile requires five prompts, passing visual "
+                "review, native execution, and zero fallbacks"
+            )
+        try:
+            baseline_vbench = float(evidence["vbench_baseline_mean"])
+            candidate_vbench = float(evidence["vbench_candidate_mean"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise PatchError("SGLang quality profile VBench evidence is invalid") from error
+        dimensions = evidence.get("vbench_dimensions")
+        if (
+            not math.isfinite(baseline_vbench)
+            or not math.isfinite(candidate_vbench)
+            or candidate_vbench < baseline_vbench
+            or not isinstance(dimensions, dict)
+            or set(dimensions) != _VBENCH_DIMENSIONS
+        ):
+            raise PatchError(
+                "SGLang quality profile must cover six VBench dimensions "
+                "without aggregate regression"
+            )
+        artifacts = evidence.get("artifact_sha256")
+        if not isinstance(artifacts, dict) or not artifacts:
+            raise PatchError("SGLang quality profile artifact hashes are missing")
+        if any(
+            not isinstance(digest, str) or not _SHA256.fullmatch(digest)
+            for digest in artifacts.values()
+        ):
+            raise PatchError("SGLang quality profile artifact hashes are invalid")
+        try:
+            baseline_e2e = float(evidence["baseline_e2e_seconds"])
+            candidate_e2e = float(evidence["candidate_e2e_seconds"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise PatchError(
+                "SGLang quality profile end-to-end evidence is invalid"
+            ) from error
+        if baseline_e2e <= 0 or candidate_e2e <= 0 or candidate_e2e >= baseline_e2e:
+            raise PatchError(
+                "SGLang quality profile must show positive end-to-end speedup"
+            )
 
     @staticmethod
     def _compare_source_hashes(root: Path, source_hashes: Mapping[str, str]) -> None:

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/placement.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/placement.py
@@ -62,7 +62,7 @@ registry backends are inventory, not an implicit priority policy.
 Every optimized path needs exact model/hardware/shape/dtype eligibility,
 native fallback or declared hard error, positive engagement and fallback
 counters, parity tests, and a benchmark. The delivered patch must expose
---agent-optimization off|auto|<profile-id>. `off` is the identity path for the
+--quality off|auto|<profile-id>. `off` is the identity path for the
 locked source revision. `auto` may activate only when the immutable profile
 matches. Native SGLang backend logs are mandatory; any Diffusers fallback
 invalidates performance evidence.

--- a/sgl-engine-sglang-diffusion/tests/test_patcher.py
+++ b/sgl-engine-sglang-diffusion/tests/test_patcher.py
@@ -32,7 +32,7 @@ def write_candidate(repository: Path, base: str, *, derived: object = None) -> N
     agent.mkdir(parents=True)
     for name in ("registry.py", "manifest.py", "runtime.py", "receipt.py"):
         (agent / name).write_text(
-            'OPTION = "--agent-optimization"\nMODES = ("off", "auto")\n'
+            'OPTION = "--quality"\nMODES = ("off", "auto")\n'
         )
     model = agent / "diffusion/test-model"
     model.mkdir(parents=True)
@@ -47,7 +47,7 @@ def write_candidate(repository: Path, base: str, *, derived: object = None) -> N
         "hardware": {"gpu": "test"},
         "workload": {"width": 64},
         "techniques": {"kernel": {"enabled": True}},
-        "server_args": {"agent_optimization": "profile-1"},
+        "server_args": {"quality": "profile-1"},
         "fallback_policy": "native",
         "source_hashes": {
             "python/sglang/kernels/agent/diffusion/test-model/kernel.py": (
@@ -60,6 +60,37 @@ def write_candidate(repository: Path, base: str, *, derived: object = None) -> N
     if derived is not None:
         profile["derived_checkpoint"] = derived
     (model / "manifest.json").write_text(json.dumps(profile))
+    quality_root = (
+        repository
+        / "python/sglang/multimodal_gen/quality_profiles/profiles"
+    )
+    quality_root.mkdir(parents=True)
+    quality_profile = {
+        "schema_version": 1,
+        "profile_id": "profile-1",
+        "status": "validated",
+        "model_ids": ["test/model"],
+        "evidence": {
+            "prompt_count": 5,
+            "visual_overall": "pass",
+            "native_backend": True,
+            "fallback_count": 0,
+            "vbench_baseline_mean": 0.8,
+            "vbench_candidate_mean": 0.81,
+            "vbench_dimensions": {
+                "subject_consistency": [0.8, 0.81],
+                "background_consistency": [0.8, 0.81],
+                "motion_smoothness": [0.8, 0.81],
+                "temporal_flickering": [0.8, 0.81],
+                "aesthetic_quality": [0.8, 0.81],
+                "imaging_quality": [0.8, 0.81],
+            },
+            "baseline_e2e_seconds": 10.0,
+            "candidate_e2e_seconds": 5.0,
+            "artifact_sha256": {"visual_verdict": "c" * 64},
+        },
+    }
+    (quality_root / "profile-1.json").write_text(json.dumps(quality_profile))
     run(["git", "add", "."], cwd=repository)
     run(["git", "commit", "-m", "candidate"], cwd=repository)
 

--- a/sgl-engine-sglang-diffusion/tests/test_placement.py
+++ b/sgl-engine-sglang-diffusion/tests/test_placement.py
@@ -26,7 +26,7 @@ def test_detects_current_unified_layout_and_renders_canonical_paths(
     assert "python/sglang/kernels/jit/csrc/diffusion/agent/wan-a14b/" in rendered
     assert "python/sglang/kernels/aot/csrc/diffusion/agent/wan-a14b/" in rendered
     assert "sglang.kernels.ops namespace" in rendered
-    assert "--agent-optimization off|auto|<profile-id>" in rendered
+    assert "--quality off|auto|<profile-id>" in rendered
 
 
 def test_detects_legacy_jit_layout_without_using_unlocked_host_paths(

--- a/skills/sglang-diffusion-auto-optimize/SKILL.md
+++ b/skills/sglang-diffusion-auto-optimize/SKILL.md
@@ -209,6 +209,16 @@ The tool integrates only verified latency-positive candidates. It does not
 wait for every suggested technique and never adds isolated speedups.
 Composition conflicts return to this root agent for a changed candidate.
 
+Package every deployable profile through SGLang Diffusion's
+`--quality off|auto|<profile-id>` contract. Keep the detailed generated
+implementation manifest under the model-scoped kernel subtree, and add the
+matching strict runtime manifest under
+`sglang.multimodal_gen.quality_profiles.profiles`. The two profile IDs,
+model IDs, workload, activation arguments, and evidence bindings must agree.
+Emit `status: validated` only after the integrated five-prompt quality gate,
+native-backend/no-fallback verification, and positive end-to-end measurement
+pass. Do not create a second profile CLI.
+
 Use:
 
 ```bash


### PR DESCRIPTION
## What changed

- switch the packaged runtime entry from the workflow-only `--agent-optimization` flag to SGLang Diffusion’s `--quality off|auto|<profile-id>` contract
- require every packaged candidate to include a matching validated SGLang quality manifest
- verify five-prompt visual evidence, native execution, zero fallbacks, artifact hashes, and positive end-to-end speedup before packaging
- bind the quality-profile SHA-256 into the patch bundle manifest
- update the auto-optimize skill and placement contract so future generated patches use this interface

## Why

The workflow previously generated a separate profile interface that could not compose with SGLang Diffusion’s runtime. This makes the controller package the same strict manifest consumed by `--quality`, while keeping detailed generated kernel metadata model-scoped.

## Validation

- `python3 -m pytest -q sgl-engine-sglang-diffusion/tests` — 124 passed
- `quick_validate.py skills/sglang-diffusion-auto-optimize` — passed
- `git diff --check` — passed