### PR TITLE
Use mean per-request E2E latency throughout diffusion optimization

### DIFF
--- a/docs/superpowers/plans/2026-08-01-diffusion-mean-e2e-timing.md
+++ b/docs/superpowers/plans/2026-08-01-diffusion-mean-e2e-timing.md
@@ -1,0 +1,230 @@
+# Diffusion Per-Request Mean E2E Timing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make per-request mean E2E latency the Controller's sole authoritative optimization metric while preserving the five-request wall time as audited evidence.
+
+**Architecture:** Normalize every raw benchmark into an explicit timing triple: mean E2E, complete workload duration, and successful request count. Version baseline, performance, delivery, and progress artifacts around those names; independently recompute and cross-check the mean in the Driver and Verifier before speedup or target decisions.
+
+**Tech Stack:** Python 3.11, Pydantic 2, pytest, JSON Schema, Markdown contracts, GitHub Actions.
+
+---
+
+### Task 1: Normalize raw benchmark timing into explicit mean and total fields
+
+**Files:**
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/driver.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_driver.py`
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Add a five-request raw result with `total_duration_seconds=400.0` and
+`latency_per_request_seconds=80.0`, then require:
+
+```python
+assert normalized["mean_e2e_s"] == 80.0
+assert normalized["workload_total_s"] == 400.0
+assert normalized["request_count"] == 5
+assert "total_s" not in normalized
+```
+
+Add rejection tests for a reported mean inconsistent with total/count and for
+missing successful-request count.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+Run:
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src pytest -q tests/test_driver.py
+```
+
+Expected: assertions fail because the Driver still emits `total_s`.
+
+- [ ] **Step 3: Implement independent mean computation**
+
+Change `normalize_output` to require the exact successful count, extract the
+complete duration, compute `mean_e2e_s = workload_total_s / successful`, and
+validate any raw `latency_per_request_seconds` with `math.isclose`.
+
+- [ ] **Step 4: Re-run the focused tests**
+
+Run the command from Step 2. Expected: all driver tests pass.
+
+### Task 2: Version baseline, delivery, and integrated performance artifacts
+
+**Files:**
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/models.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/baseline.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/artifacts.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_artifacts.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_integration_flow.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_final_quality.py`
+- Modify generated files under: `sgl-engine-sglang-diffusion/schemas/`
+
+- [ ] **Step 1: Add failing model and integration expectations**
+
+Require `BaselineRecord` schema 2 to expose:
+
+```python
+mean_e2e_s=80.0
+workload_total_s=400.0
+request_count=5
+```
+
+Require `PerformanceRecord` to expose baseline/candidate mean, totals, and one
+frozen request count, and reject the old ambiguous timing field names.
+
+- [ ] **Step 2: Run artifact and integration tests**
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src pytest -q tests/test_artifacts.py tests/test_integration_flow.py tests/test_final_quality.py
+```
+
+Expected: failures on missing explicit timing fields.
+
+- [ ] **Step 3: Implement the schema-2 models and producers**
+
+Make baseline and integration consume the Driver's explicit timing triple.
+Compute speedup only from baseline/candidate mean values, while retaining both
+workload totals in the delivery record.
+
+- [ ] **Step 4: Regenerate schemas and rerun tests**
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src python3 -c 'from pathlib import Path; from sgl_engine_sglang_diffusion.artifacts import write_schemas; write_schemas(Path("schemas"))'
+PYTHONPATH=src pytest -q tests/test_artifacts.py tests/test_integration_flow.py tests/test_final_quality.py
+```
+
+Expected: generated schemas match and focused tests pass.
+
+### Task 3: Make independent verification recompute the mean
+
+**Files:**
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_verifier.py`
+
+- [ ] **Step 1: Add tamper tests**
+
+Create independently failing cases for candidate mean, complete workload total,
+and request-count drift. Each must produce a deterministic verification finding.
+
+- [ ] **Step 2: Run verifier tests and confirm failure**
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src pytest -q tests/test_verifier.py
+```
+
+- [ ] **Step 3: Recompute raw benchmark timing in the Verifier**
+
+Require five successful requests, recompute raw mean from total/count, compare
+the raw triple with `PERFORMANCE.json` and the delivery record, and calculate
+authoritative speedup from mean values only.
+
+- [ ] **Step 4: Re-run verifier tests**
+
+Expected: all valid points pass and every timing tamper fails closed.
+
+### Task 4: Update Controller decisions, progress, prompts, and E2E fixtures
+
+**Files:**
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/controller.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_controller.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_progress.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_runtime_e2e.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py`
+- Modify: `sgl-engine-sglang-diffusion/tests/test_orchestration.py`
+
+- [ ] **Step 1: Add failing target and rendering expectations**
+
+Require target latency to use `baseline.mean_e2e_s`, and progress output to
+render both:
+
+```text
+latency     80.0000s/request baseline -> 40.0000s/request integrated
+workload    400.0000s/5 requests -> 200.0000s/5 requests
+```
+
+- [ ] **Step 2: Run focused controller/runtime tests**
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src pytest -q tests/test_controller.py tests/test_progress.py tests/test_runtime_e2e.py tests/test_runtime_scheduler.py tests/test_orchestration.py
+```
+
+- [ ] **Step 3: Update all scientific consumers and fixtures**
+
+Replace ambiguous timing keys in target checks, candidate registry summaries,
+executor prompts, progress JSON, and fake Agent deliveries. Preserve the full
+five-prompt gate and all non-timing contracts.
+
+- [ ] **Step 4: Re-run the focused suite**
+
+Expected: Controller and E2E tests pass using mean latency throughout.
+
+### Task 5: Update public documentation, skill contract, and standalone prompt
+
+**Files:**
+- Modify: `sgl-engine-sglang-diffusion/README.md`
+- Modify: `sgl-engine-sglang-diffusion/prompts/executor.md`
+- Modify: `sgl-engine-sglang-diffusion/prompts/master.md`
+- Modify: `skills/sglang-diffusion-auto-optimize/SKILL.md`
+- Modify: `skills/sglang-diffusion-auto-optimize/references/progress-contract.md`
+- Modify after merge: `/Users/bbuf/工作目录/Common/prompt.md`
+
+- [ ] **Step 1: Replace ambiguous total-latency language**
+
+Document that mean E2E is authoritative, workload total is audit-only, exactly
+five prompts remain mandatory, and speedups are never accumulated.
+
+- [ ] **Step 2: Search for stale field names and semantics**
+
+```bash
+rg -n "baseline_total_s|candidate_total_s|integrated_total_s|frozen_baseline_total_s|total_s" \
+  sgl-engine-sglang-diffusion skills/sglang-diffusion-auto-optimize
+```
+
+Expected: only explicitly documented obsolete-schema rejection or unrelated
+wall-clock concepts remain.
+
+### Task 6: Validate, publish, merge, and install
+
+**Files:**
+- Modify test fixtures only if the complete suite exposes legitimate stale
+  timing fields.
+
+- [ ] **Step 1: Run complete local validation**
+
+```bash
+cd sgl-engine-sglang-diffusion
+PYTHONPATH=src pytest -q
+PYTHONPATH=src python3 -m compileall -q src tests
+ruff check src tests
+```
+
+From the repository root, run changed-file pre-commit checks and
+`git diff --check`, then build a wheel into a temporary directory.
+
+- [ ] **Step 2: Commit and publish**
+
+Commit the implementation, push `agent/mean-e2e-timing`, open a draft PR with
+the timing-contract rationale and validation results, wait for required CI, mark
+ready, and squash merge.
+
+- [ ] **Step 3: Reinstall and verify the local skill**
+
+Back up the current installed skill, install from the exact merge commit, and
+require `diff -qr` against the merged repository source to succeed.
+
+- [ ] **Step 4: Update and validate `prompt.md`**
+
+Use the merged commit and tool paths, replace five-prompt-total target wording
+with per-request-mean wording, parse the embedded launch request, and confirm
+the 5.0 target and frozen command remain unchanged.

--- a/docs/superpowers/specs/2026-08-01-diffusion-mean-e2e-timing-design.md
+++ b/docs/superpowers/specs/2026-08-01-diffusion-mean-e2e-timing-design.md
@@ -1,0 +1,120 @@
+# Per-Request Mean E2E Timing for Diffusion Campaigns
+
+## Goal
+
+Make the Controller use the arithmetic mean end-to-end latency of the five
+successful frozen requests as the only authoritative latency for baseline,
+candidate comparison, integration, progress, target evaluation, and final
+delivery. Preserve the complete five-request wall time as audit evidence.
+
+## Motivation
+
+The native offline benchmark emits both a complete-workload duration and a
+per-request latency. The current Controller stores the complete duration in a
+field named `total_s`, while historical reports commonly publish the mean per
+request. Both yield the same speedup when request count is unchanged, but the
+different displayed scale makes an approximately 78-second request look
+inconsistent with an approximately 390-second five-request campaign.
+
+The flow already freezes exactly five prompts and rejects missing requests.
+Using an explicitly named mean therefore improves reporting without weakening
+the full-workload gate.
+
+## Chosen design
+
+### Authoritative and audit metrics
+
+Every normalized benchmark record carries:
+
+- `mean_e2e_s`: arithmetic mean across successful frozen requests;
+- `workload_total_s`: measured duration covering the complete five-request
+  workload;
+- `request_count`: successful request count, required to equal the frozen goal;
+- `peak_memory_mib`, `timing_scope`, and the raw benchmark result.
+
+The Controller computes `mean_e2e_s` itself as
+`workload_total_s / request_count`. If the benchmark also reports
+`latency_per_request_seconds`, the Controller requires it to agree within a
+small floating-point tolerance. Executor-provided averages are never trusted
+without the raw total and count.
+
+### Versioned public artifacts
+
+New campaigns use explicit schema-version-2 timing fields:
+
+- `BaselineRecord`: `mean_e2e_s`, `workload_total_s`, and `request_count`;
+- normalized `PERFORMANCE.json`: the same timing triple;
+- delivery `PerformanceRecord`: baseline/candidate mean, workload total, and
+  request count, plus the speedup;
+- progress JSON: `baseline_mean_e2e_s` and `integrated_mean_e2e_s`, with the
+  totals retained under separately named audit fields.
+
+The ambiguous `total_s`, `baseline_total_s`, and `candidate_total_s` fields are
+not accepted in new artifacts. Campaigns are installed from immutable
+Controller revisions, so an existing campaign continues on its pinned version.
+The new Controller fails closed if manually pointed at an old timing artifact
+instead of silently reinterpreting it.
+
+### Measurement and verification flow
+
+1. Run all five prompts under the frozen command.
+2. Require exactly five successful and zero failed requests.
+3. Extract the complete workload duration and independently compute the mean.
+4. Freeze both values in `BASELINE.json`.
+5. Require every candidate and integrated run to emit the same count and both
+   timing values.
+6. Recompute authoritative speedup only as
+   `baseline_mean_e2e_s / candidate_mean_e2e_s`.
+7. Use the mean for target latency, frontier admission, progress, terminal
+   status, and user-facing reports.
+8. Keep workload totals for audit and consistency checks; never use them as the
+   displayed optimization baseline.
+
+Profile capture, media production, quality evidence, GPU identity, frozen
+topology, and five-prompt authenticity remain unchanged.
+
+## Error handling
+
+The run fails closed when:
+
+- successful request count is missing or differs from five;
+- the complete workload duration is missing, non-finite, or non-positive;
+- the recomputed mean is non-finite or non-positive;
+- a reported per-request latency disagrees with total divided by count;
+- baseline and candidate request counts differ;
+- a delivery reports mean or total values that differ from its hashed raw
+  benchmark evidence; or
+- an artifact uses the obsolete ambiguous timing schema.
+
+## User-facing behavior
+
+Progress renders latency as, for example:
+
+```text
+latency     78.1011s/request baseline -> 39.3386s/request integrated
+workload    390.5056s/5 requests -> 196.6928s/5 requests
+```
+
+The first line is authoritative. The second is audit context. Skill and flow
+documentation consistently describe the target as a ratio of per-request mean
+E2E latency. `prompt.md` uses the same wording while keeping the exact five
+prompts and command unchanged.
+
+## Testing
+
+- Driver tests prove a five-request total is divided by five and cross-checked
+  against the raw mean.
+- Driver tests reject count drift and inconsistent raw per-request latency.
+- Baseline, delivery, integration, verifier, progress, controller, and E2E
+  fixtures use the versioned fields.
+- Verifier tests reject tampered mean, total, and request count independently.
+- Checked-in JSON Schemas must match deterministic regeneration.
+- The full pytest, compileall, Ruff, pre-commit, diff-check, and wheel build
+  suite must pass before publication.
+
+## Delivery
+
+Publish the implementation as a pull request, wait for required checks, squash
+merge it, reinstall the merged `sglang-diffusion-auto-optimize` skill locally,
+and update `/Users/bbuf/工作目录/Common/prompt.md` to the merged
+Controller revision and per-request-mean wording.

--- a/sgl-engine-sglang-diffusion/README.md
+++ b/sgl-engine-sglang-diffusion/README.md
@@ -305,8 +305,15 @@ implementation manifests, engagement/fallback receipts, and candidate commits.
 It recomputes:
 
 ```text
-speedup = frozen_baseline_total_s / candidate_total_s
+baseline_mean_e2e_s = baseline_workload_total_s / 5
+candidate_mean_e2e_s = candidate_workload_total_s / 5
+speedup = baseline_mean_e2e_s / candidate_mean_e2e_s
 ```
+
+The per-successful-request arithmetic mean is the sole optimization and target
+metric throughout the campaign. The complete five-request wall time and the
+request count remain in every durable record as audit evidence; they are never
+used as ambiguously named latency fields.
 
 It rejects projected microbenchmark gains, altered timing scopes, fallback
 backends, no-op flags, baseline resubmissions, path escapes, fabricated
@@ -460,7 +467,8 @@ Before publishing a result, rerun on the locked GPU class and workload:
 
 1. apply the bundle in a new detached worktree;
 2. run all packaged import/unit checks;
-3. run the exact five-prompt native SGLang benchmark;
+3. run the exact five-prompt native SGLang benchmark and independently compute
+   its per-successful-request arithmetic mean;
 4. confirm no Diffusers fallback marker appears;
 5. confirm every selected technique has positive engagement;
 6. rerun the applicable lossless or quality gate; and

--- a/sgl-engine-sglang-diffusion/prompts/executor.md
+++ b/sgl-engine-sglang-diffusion/prompts/executor.md
@@ -9,6 +9,13 @@ baseline, workload, timing scope, real-run artifacts, source hashes, activation
 evidence, and OFF identity. One round is one hypothesis, one candidate, one
 real run, and one applicable gate.
 
+The authoritative performance metric is always the arithmetic mean E2E time
+per successful request over the exact five-request workload. Preserve all
+three explicit values in every result: `mean_e2e_s`, `workload_total_s`, and
+`request_count: 5`. Compute speedup from baseline mean divided by candidate
+mean. Never optimize against, compare, or report the five-request total as if
+it were a single-request latency.
+
 The active-lane historical rule section contains manually diff-reviewed SGLang
 PR patterns. Use it to generate hypotheses only. Do not copy its GPU threshold,
 layer count, rank count, shape, or speed claim as applicability or acceptance

--- a/sgl-engine-sglang-diffusion/prompts/master.md
+++ b/sgl-engine-sglang-diffusion/prompts/master.md
@@ -4,6 +4,13 @@ Treat every executor claim as untrusted until independently checked against the
 locked source, frozen baseline, real run directory, and applicable Sol-Engine
 contract.
 
+Independently derive `mean_e2e_s = workload_total_s / request_count` from the
+raw benchmark. Require exactly five successful requests and zero failed
+requests, cross-check any benchmark-reported per-request latency, and compute
+speedup only as frozen baseline mean divided by candidate mean. Reject legacy
+or ambiguous `total_s`, `baseline_total_s`, and `candidate_total_s` fields in
+new artifacts.
+
 Recompute performance from benchmark artifacts. Verify provenance, exact
 workload and timing scope, actual technique engagement, fallback counters,
 source hashes, OFF identity, and implementation semantics. For lossless lanes,

--- a/sgl-engine-sglang-diffusion/schemas/baseline.schema.json
+++ b/sgl-engine-sglang-diffusion/schemas/baseline.schema.json
@@ -6,6 +6,11 @@
       "title": "Baseline Frames",
       "type": "string"
     },
+    "mean_e2e_s": {
+      "exclusiveMinimum": 0.0,
+      "title": "Mean E2E S",
+      "type": "number"
+    },
     "model_id": {
       "title": "Model Id",
       "type": "string"
@@ -15,14 +20,19 @@
       "title": "Peak Memory Mib",
       "type": "number"
     },
+    "request_count": {
+      "const": 5,
+      "default": 5,
+      "title": "Request Count"
+    },
     "run_dir": {
       "format": "path",
       "title": "Run Dir",
       "type": "string"
     },
     "schema_version": {
-      "const": 1,
-      "default": 1,
+      "const": 2,
+      "default": 2,
       "title": "Schema Version"
     },
     "sglang_commit": {
@@ -34,15 +44,16 @@
       "title": "Timing Scope",
       "type": "string"
     },
-    "total_s": {
+    "workload_total_s": {
       "exclusiveMinimum": 0.0,
-      "title": "Total S",
+      "title": "Workload Total S",
       "type": "number"
     }
   },
   "required": [
     "model_id",
-    "total_s",
+    "mean_e2e_s",
+    "workload_total_s",
     "peak_memory_mib",
     "timing_scope",
     "run_dir",

--- a/sgl-engine-sglang-diffusion/schemas/delivery.schema.json
+++ b/sgl-engine-sglang-diffusion/schemas/delivery.schema.json
@@ -50,14 +50,24 @@
     "PerformanceRecord": {
       "additionalProperties": false,
       "properties": {
-        "baseline_total_s": {
+        "baseline_mean_e2e_s": {
           "exclusiveMinimum": 0.0,
-          "title": "Baseline Total S",
+          "title": "Baseline Mean E2E S",
           "type": "number"
         },
-        "candidate_total_s": {
+        "baseline_workload_total_s": {
           "exclusiveMinimum": 0.0,
-          "title": "Candidate Total S",
+          "title": "Baseline Workload Total S",
+          "type": "number"
+        },
+        "candidate_mean_e2e_s": {
+          "exclusiveMinimum": 0.0,
+          "title": "Candidate Mean E2E S",
+          "type": "number"
+        },
+        "candidate_workload_total_s": {
+          "exclusiveMinimum": 0.0,
+          "title": "Candidate Workload Total S",
           "type": "number"
         },
         "frontier_axis": {
@@ -68,6 +78,16 @@
           "title": "Frontier Axis",
           "type": "string"
         },
+        "request_count": {
+          "const": 5,
+          "default": 5,
+          "title": "Request Count"
+        },
+        "schema_version": {
+          "const": 2,
+          "default": 2,
+          "title": "Schema Version"
+        },
         "speedup": {
           "exclusiveMinimum": 0.0,
           "title": "Speedup",
@@ -76,8 +96,10 @@
       },
       "required": [
         "frontier_axis",
-        "baseline_total_s",
-        "candidate_total_s",
+        "baseline_mean_e2e_s",
+        "candidate_mean_e2e_s",
+        "baseline_workload_total_s",
+        "candidate_workload_total_s",
         "speedup"
       ],
       "title": "PerformanceRecord",

--- a/sgl-engine-sglang-diffusion/schemas/integrated-delivery.schema.json
+++ b/sgl-engine-sglang-diffusion/schemas/integrated-delivery.schema.json
@@ -50,14 +50,24 @@
     "PerformanceRecord": {
       "additionalProperties": false,
       "properties": {
-        "baseline_total_s": {
+        "baseline_mean_e2e_s": {
           "exclusiveMinimum": 0.0,
-          "title": "Baseline Total S",
+          "title": "Baseline Mean E2E S",
           "type": "number"
         },
-        "candidate_total_s": {
+        "baseline_workload_total_s": {
           "exclusiveMinimum": 0.0,
-          "title": "Candidate Total S",
+          "title": "Baseline Workload Total S",
+          "type": "number"
+        },
+        "candidate_mean_e2e_s": {
+          "exclusiveMinimum": 0.0,
+          "title": "Candidate Mean E2E S",
+          "type": "number"
+        },
+        "candidate_workload_total_s": {
+          "exclusiveMinimum": 0.0,
+          "title": "Candidate Workload Total S",
           "type": "number"
         },
         "frontier_axis": {
@@ -68,6 +78,16 @@
           "title": "Frontier Axis",
           "type": "string"
         },
+        "request_count": {
+          "const": 5,
+          "default": 5,
+          "title": "Request Count"
+        },
+        "schema_version": {
+          "const": 2,
+          "default": 2,
+          "title": "Schema Version"
+        },
         "speedup": {
           "exclusiveMinimum": 0.0,
           "title": "Speedup",
@@ -76,8 +96,10 @@
       },
       "required": [
         "frontier_axis",
-        "baseline_total_s",
-        "candidate_total_s",
+        "baseline_mean_e2e_s",
+        "candidate_mean_e2e_s",
+        "baseline_workload_total_s",
+        "candidate_workload_total_s",
         "speedup"
       ],
       "title": "PerformanceRecord",

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/baseline.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/baseline.py
@@ -50,7 +50,9 @@ class BaselineRunner:
             )
             record = BaselineRecord(
                 model_id=goal.model.id,
-                total_s=benchmark.normalized["total_s"],
+                mean_e2e_s=benchmark.normalized["mean_e2e_s"],
+                workload_total_s=benchmark.normalized["workload_total_s"],
+                request_count=benchmark.normalized["request_count"],
                 peak_memory_mib=benchmark.normalized["peak_memory_mib"],
                 timing_scope=goal.workload.timing_scope,
                 run_dir=benchmark.run_dir,

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/controller.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/controller.py
@@ -233,7 +233,7 @@ class CampaignController:
         prompt_hash = hashlib.sha256(
             self.goal.workload.prompts.read_bytes()
         ).hexdigest()
-        target_latency = baseline.total_s / self.goal.goal.target_speedup
+        target_latency = baseline.mean_e2e_s / self.goal.goal.target_speedup
         return (
             certificate.frozen_workload_sha256 == prompt_hash
             and certificate.hardware == self.goal.hardware.model_dump(mode="json")

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/driver.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import sys
 from collections.abc import Callable, Mapping, Sequence
@@ -311,14 +312,20 @@ class SGLangDiffusionDriver:
 
         successful = results.get("successful_requests")
         failed = results.get("failed_requests")
-        if successful is not None and int(successful) != expected_requests:
+        if not isinstance(successful, int) or isinstance(successful, bool):
+            raise DriverError(
+                "benchmark successful request count is missing or invalid"
+            )
+        if successful != expected_requests:
             raise DriverError(
                 f"expected {expected_requests} successful requests, got {successful}"
             )
-        if failed is not None and int(failed) != 0:
+        if not isinstance(failed, int) or isinstance(failed, bool):
+            raise DriverError("benchmark failed request count is missing or invalid")
+        if failed != 0:
             raise DriverError(f"benchmark reported {failed} failed requests")
 
-        total = SGLangDiffusionDriver._first_number(
+        workload_total = SGLangDiffusionDriver._first_number(
             results,
             ("total_duration_seconds", "total_s", "latency"),
         )
@@ -326,13 +333,35 @@ class SGLangDiffusionDriver:
             results,
             ("peak_memory_mb", "peak_memory_mib"),
         )
-        if total is None or total <= 0:
-            raise DriverError("benchmark latency must be positive")
+        if (
+            workload_total is None
+            or not math.isfinite(workload_total)
+            or workload_total <= 0
+        ):
+            raise DriverError("benchmark workload duration must be finite and positive")
         if peak is None or peak <= 0:
             raise DriverError("benchmark peak memory must be present and positive")
+        mean_e2e = workload_total / successful
+        if not math.isfinite(mean_e2e) or mean_e2e <= 0:
+            raise DriverError("benchmark per-request mean must be finite and positive")
+        reported_mean = SGLangDiffusionDriver._first_number(
+            results,
+            ("latency_per_request_seconds",),
+        )
+        if reported_mean is not None and not math.isclose(
+            reported_mean,
+            mean_e2e,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise DriverError(
+                "benchmark per-request latency disagrees with workload total/count"
+            )
         return {
-            "schema_version": 1,
-            "total_s": total,
+            "schema_version": 2,
+            "mean_e2e_s": mean_e2e,
+            "workload_total_s": workload_total,
+            "request_count": successful,
             "peak_memory_mib": peak,
             "timing_scope": timing_scope,
             "raw_result": raw,

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py
@@ -504,16 +504,21 @@ class IntegrationManager:
                 "integrated benchmark timing scope differs from frozen baseline: "
                 f"{timing_scope!r} != {baseline.timing_scope!r}"
             )
-        candidate_total_s = float(benchmark.normalized["total_s"])
-        if not math.isfinite(candidate_total_s) or candidate_total_s <= 0:
+        candidate_mean_e2e_s = float(benchmark.normalized["mean_e2e_s"])
+        candidate_workload_total_s = float(benchmark.normalized["workload_total_s"])
+        request_count = int(benchmark.normalized["request_count"])
+        if not math.isfinite(candidate_mean_e2e_s) or candidate_mean_e2e_s <= 0:
             raise IntegrationError(
                 "integrated benchmark latency must be finite and positive"
             )
         return PerformanceRecord(
             frontier_axis="latency",
-            baseline_total_s=baseline.total_s,
-            candidate_total_s=candidate_total_s,
-            speedup=baseline.total_s / candidate_total_s,
+            baseline_mean_e2e_s=baseline.mean_e2e_s,
+            candidate_mean_e2e_s=candidate_mean_e2e_s,
+            baseline_workload_total_s=baseline.workload_total_s,
+            candidate_workload_total_s=candidate_workload_total_s,
+            request_count=request_count,
+            speedup=baseline.mean_e2e_s / candidate_mean_e2e_s,
         )
 
     @staticmethod

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/models.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
@@ -101,21 +102,52 @@ class SourceLock(StrictModel):
 
 
 class BaselineRecord(StrictModel):
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     model_id: str
-    total_s: float = Field(gt=0)
+    mean_e2e_s: float = Field(gt=0)
+    workload_total_s: float = Field(gt=0)
+    request_count: Literal[5] = 5
     peak_memory_mib: float = Field(gt=0)
     timing_scope: str
     run_dir: Path
     baseline_frames: Path
     sglang_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
 
+    @model_validator(mode="after")
+    def require_consistent_timing(self) -> BaselineRecord:
+        expected_total = self.mean_e2e_s * self.request_count
+        if not math.isclose(
+            self.workload_total_s, expected_total, rel_tol=1e-9, abs_tol=1e-9
+        ):
+            raise ValueError("workload_total_s must equal mean_e2e_s * request_count")
+        return self
+
 
 class PerformanceRecord(StrictModel):
+    schema_version: Literal[2] = 2
     frontier_axis: Literal["latency", "peak_memory"]
-    baseline_total_s: float = Field(gt=0)
-    candidate_total_s: float = Field(gt=0)
+    baseline_mean_e2e_s: float = Field(gt=0)
+    candidate_mean_e2e_s: float = Field(gt=0)
+    baseline_workload_total_s: float = Field(gt=0)
+    candidate_workload_total_s: float = Field(gt=0)
+    request_count: Literal[5] = 5
     speedup: float = Field(gt=0)
+
+    @model_validator(mode="after")
+    def require_consistent_timing(self) -> PerformanceRecord:
+        pairs = (
+            (self.baseline_workload_total_s, self.baseline_mean_e2e_s),
+            (self.candidate_workload_total_s, self.candidate_mean_e2e_s),
+        )
+        for workload_total, mean_e2e in pairs:
+            if not math.isclose(
+                workload_total,
+                mean_e2e * self.request_count,
+                rel_tol=1e-9,
+                abs_tol=1e-9,
+            ):
+                raise ValueError("workload total must equal mean_e2e_s * request_count")
+        return self
 
 
 class QualityRecord(StrictModel):

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py
@@ -34,16 +34,19 @@ def build_progress(campaign: Path) -> dict[str, Any]:
     attempts = _technique_attempts(events)
     scientific_rounds = _scientific_rounds(events)
     isolated = _isolated_speedups(campaign)
-    integrated_speedup, integrated_total_s, integrated_techniques = _integrated(
-        campaign
-    )
+    (
+        integrated_speedup,
+        integrated_mean_e2e_s,
+        integrated_workload_total_s,
+        integrated_request_count,
+        integrated_techniques,
+    ) = _integrated(campaign)
     baseline_record = _read_object_optional(campaign / "BASELINE.json") or {}
-    raw_baseline_total = baseline_record.get("total_s")
-    baseline_total_s = (
-        float(raw_baseline_total)
-        if isinstance(raw_baseline_total, (int, float))
-        and not isinstance(raw_baseline_total, bool)
-        else None
+    baseline_mean_e2e_s = _number(baseline_record.get("mean_e2e_s"))
+    baseline_workload_total_s = _number(baseline_record.get("workload_total_s"))
+    raw_baseline_count = baseline_record.get("request_count")
+    baseline_request_count = (
+        raw_baseline_count if type(raw_baseline_count) is int else None
     )
     rows: list[dict[str, Any]] = []
     for technique in routes:
@@ -104,7 +107,7 @@ def build_progress(campaign: Path) -> dict[str, Any]:
     patch = campaign / "patch" / "sglang.patch"
     certificate = campaign / "UNREACHABLE.json"
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "campaign_id": campaign_id,
         "campaign": str(campaign),
         "model": str(goal["model"]["id"]),
@@ -116,8 +119,12 @@ def build_progress(campaign: Path) -> dict[str, Any]:
         "updated_at": now.isoformat(),
         "elapsed_seconds": elapsed,
         "target_speedup": target,
-        "baseline_total_s": baseline_total_s,
-        "integrated_total_s": integrated_total_s,
+        "baseline_mean_e2e_s": baseline_mean_e2e_s,
+        "baseline_workload_total_s": baseline_workload_total_s,
+        "baseline_request_count": baseline_request_count,
+        "integrated_mean_e2e_s": integrated_mean_e2e_s,
+        "integrated_workload_total_s": integrated_workload_total_s,
+        "integrated_request_count": integrated_request_count,
         "best_verified_speedup": best,
         "integrated_stack_speedup": integrated_speedup,
         "performance_progress": performance_fraction,
@@ -208,11 +215,30 @@ def render_progress(progress: dict[str, Any]) -> str:
             "technique          state       gate           tries  isolated e2e",
         ]
     )
-    if progress["baseline_total_s"] is not None:
-        latency = f"latency     {progress['baseline_total_s']:.4f}s baseline"
-        if progress["integrated_total_s"] is not None:
-            latency += f" -> {progress['integrated_total_s']:.4f}s integrated"
+    if progress["baseline_mean_e2e_s"] is not None:
+        latency = f"latency     {progress['baseline_mean_e2e_s']:.4f}s/request baseline"
+        if progress["integrated_mean_e2e_s"] is not None:
+            latency += (
+                f" -> {progress['integrated_mean_e2e_s']:.4f}s/request integrated"
+            )
         lines.insert(5, latency)
+    if (
+        progress["baseline_workload_total_s"] is not None
+        and progress["baseline_request_count"] is not None
+    ):
+        workload = (
+            f"workload    {progress['baseline_workload_total_s']:.4f}s/"
+            f"{progress['baseline_request_count']} requests baseline"
+        )
+        if (
+            progress["integrated_workload_total_s"] is not None
+            and progress["integrated_request_count"] is not None
+        ):
+            workload += (
+                f" -> {progress['integrated_workload_total_s']:.4f}s/"
+                f"{progress['integrated_request_count']} requests integrated"
+            )
+        lines.insert(6, workload)
     for row in progress["techniques"]:
         speedup = row["best_isolated_e2e_speedup"]
         speedup_text = f"{speedup:.2f}x" if speedup is not None else "-"
@@ -326,9 +352,11 @@ def _isolated_speedups(campaign: Path) -> dict[str, float]:
 
 def _integrated(
     campaign: Path,
-) -> tuple[float | None, float | None, set[str]]:
+) -> tuple[float | None, float | None, float | None, int | None, set[str]]:
     speedup: float | None = None
-    candidate_total_s: float | None = None
+    candidate_mean_e2e_s: float | None = None
+    candidate_workload_total_s: float | None = None
+    request_count: int | None = None
     techniques: set[str] = set()
     for path in sorted(
         campaign.glob("integration/*/attempt-*/INTEGRATED-DELIVERY.json")
@@ -364,13 +392,27 @@ def _integrated(
                     if speedup is None or measured >= speedup:
                         speedup = measured
                         techniques = point_techniques
-                        candidate_total_s = None
-                        raw_total = performance.get("candidate_total_s")
-                        if isinstance(raw_total, (int, float)) and not isinstance(
-                            raw_total, bool
-                        ):
-                            candidate_total_s = float(raw_total)
-    return speedup, candidate_total_s, techniques
+                        candidate_mean_e2e_s = _number(
+                            performance.get("candidate_mean_e2e_s")
+                        )
+                        candidate_workload_total_s = _number(
+                            performance.get("candidate_workload_total_s")
+                        )
+                        raw_count = performance.get("request_count")
+                        request_count = raw_count if type(raw_count) is int else None
+    return (
+        speedup,
+        candidate_mean_e2e_s,
+        candidate_workload_total_s,
+        request_count,
+        techniques,
+    )
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
 
 
 def _current_work(status: CampaignStatus, events: list[dict[str, Any]]) -> str:

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py
@@ -2134,7 +2134,11 @@ class FileCampaignHooks:
                 "technique": handle.technique,
                 "candidate_id": candidate_id,
                 "delivery_sha256": sha256_file(delivery_path),
-                "candidate_total_s": performance.get("candidate_total_s"),
+                "candidate_mean_e2e_s": performance.get("candidate_mean_e2e_s"),
+                "candidate_workload_total_s": performance.get(
+                    "candidate_workload_total_s"
+                ),
+                "request_count": performance.get("request_count"),
                 "outcome": outcome,
             },
         )

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py
@@ -106,7 +106,7 @@ class VerifiedFrontierPoint:
     candidate_id: str
     run_dir: Path
     authoritative_speedup: float
-    candidate_total_s: float
+    candidate_mean_e2e_s: float
     peak_memory_mib: float
     activation: dict[str, Any]
     implementation_manifest: CandidateManifest
@@ -415,12 +415,12 @@ class DeliveryVerifier:
 
         if issues or authoritative is None or manifest is None:
             return issues, None
-        speedup, candidate_total, peak_memory = authoritative
+        speedup, candidate_mean, peak_memory = authoritative
         return issues, VerifiedFrontierPoint(
             candidate_id=candidate_id,
             run_dir=run_dir,
             authoritative_speedup=speedup,
-            candidate_total_s=candidate_total,
+            candidate_mean_e2e_s=candidate_mean,
             peak_memory_mib=peak_memory,
             activation=dict(point.activation),
             implementation_manifest=manifest,
@@ -725,38 +725,71 @@ class DeliveryVerifier:
         benchmark: Mapping[str, Any],
         issue: Any,
     ) -> tuple[float, float, float] | None:
-        candidate_total = self._positive_number(performance.get("total_s"))
+        candidate_mean = self._positive_number(performance.get("mean_e2e_s"))
+        candidate_workload_total = self._positive_number(
+            performance.get("workload_total_s")
+        )
+        request_count = performance.get("request_count")
         peak_memory = self._positive_number(performance.get("peak_memory_mib"))
-        if candidate_total is None or peak_memory is None:
+        if (
+            candidate_mean is None
+            or candidate_workload_total is None
+            or type(request_count) is not int
+            or request_count != 5
+            or peak_memory is None
+        ):
             issue(
                 "invalid_performance",
-                "PERFORMANCE.json requires positive total_s and peak_memory_mib",
+                "PERFORMANCE.json requires explicit mean_e2e_s, "
+                "workload_total_s, request_count=5, and peak_memory_mib",
             )
             return None
-        benchmark_total = self._positive_number(benchmark.get("total_s"))
+        benchmark_mean = self._positive_number(benchmark.get("mean_e2e_s"))
+        benchmark_workload_total = self._positive_number(
+            benchmark.get("workload_total_s")
+        )
+        benchmark_request_count = benchmark.get("request_count")
         benchmark_peak = self._positive_number(benchmark.get("peak_memory_mib"))
-        if benchmark_total is None or benchmark_peak is None:
+        if (
+            benchmark_mean is None
+            or benchmark_workload_total is None
+            or type(benchmark_request_count) is not int
+            or benchmark_request_count != 5
+            or benchmark_peak is None
+        ):
             issue(
                 "invalid_benchmark_metrics",
-                "benchmark requires positive latency and peak memory",
+                "benchmark requires five requests with positive mean, total, and "
+                "peak memory",
             )
             return None
-        if not math.isclose(
-            candidate_total,
-            benchmark_total,
-            rel_tol=1e-9,
-            abs_tol=1e-12,
-        ) or not math.isclose(
-            peak_memory,
-            benchmark_peak,
-            rel_tol=1e-9,
-            abs_tol=1e-9,
+        if (
+            not math.isclose(
+                candidate_mean,
+                benchmark_mean,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            or not math.isclose(
+                candidate_workload_total,
+                benchmark_workload_total,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            or not math.isclose(
+                peak_memory,
+                benchmark_peak,
+                rel_tol=1e-9,
+                abs_tol=1e-9,
+            )
         ):
             issue(
                 "benchmark_performance_mismatch",
                 "PERFORMANCE.json differs from the raw benchmark result",
             )
-        candidate_total = benchmark_total
+        candidate_mean = benchmark_mean
+        candidate_workload_total = benchmark_workload_total
+        request_count = benchmark_request_count
         peak_memory = benchmark_peak
         timing_scope = performance.get("timing_scope")
         if timing_scope != self.baseline.timing_scope:
@@ -765,26 +798,44 @@ class DeliveryVerifier:
                 "candidate timing_scope differs from the frozen baseline",
             )
         if not math.isclose(
-            point.performance.baseline_total_s,
-            self.baseline.total_s,
+            point.performance.baseline_mean_e2e_s,
+            self.baseline.mean_e2e_s,
             rel_tol=1e-12,
             abs_tol=1e-12,
         ):
             issue(
                 "baseline_tamper",
-                "reported baseline_total_s differs from the frozen baseline",
+                "reported baseline_mean_e2e_s differs from the frozen baseline",
+            )
+        if (
+            not math.isclose(
+                point.performance.baseline_workload_total_s,
+                self.baseline.workload_total_s,
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+            or point.performance.request_count != self.baseline.request_count
+        ):
+            issue(
+                "baseline_tamper",
+                "reported baseline workload timing differs from the frozen baseline",
             )
         if not math.isclose(
-            point.performance.candidate_total_s,
-            candidate_total,
+            point.performance.candidate_mean_e2e_s,
+            candidate_mean,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ) or not math.isclose(
+            point.performance.candidate_workload_total_s,
+            candidate_workload_total,
             rel_tol=1e-9,
             abs_tol=1e-12,
         ):
             issue(
                 "candidate_tamper",
-                "reported candidate_total_s differs from PERFORMANCE.json",
+                "reported candidate timing differs from PERFORMANCE.json",
             )
-        speedup = self.baseline.total_s / candidate_total
+        speedup = self.baseline.mean_e2e_s / candidate_mean
         if not math.isclose(
             speedup,
             point.performance.speedup,
@@ -796,7 +847,7 @@ class DeliveryVerifier:
                 "reported speedup does not match durable benchmark",
             )
         if point.performance.frontier_axis == "latency":
-            if candidate_total >= self.baseline.total_s:
+            if candidate_mean >= self.baseline.mean_e2e_s:
                 issue(
                     "no_improvement",
                     "latency frontier point does not improve frozen baseline latency",
@@ -806,7 +857,7 @@ class DeliveryVerifier:
                 "dominated_memory",
                 "memory frontier point does not improve frozen baseline memory",
             )
-        return speedup, candidate_total, peak_memory
+        return speedup, candidate_mean, peak_memory
 
     def _verify_lossless(
         self,
@@ -1201,7 +1252,7 @@ class DeliveryVerifier:
         raise VerificationError("required benchmark artifact is missing")
 
     @staticmethod
-    def _validate_benchmark(path: Path) -> dict[str, float]:
+    def _validate_benchmark(path: Path) -> dict[str, float | int]:
         if not path.is_file() or path.stat().st_size == 0:
             raise VerificationError("benchmark artifact is empty or not a file")
         text = path.read_text(encoding="utf-8")
@@ -1225,11 +1276,11 @@ class DeliveryVerifier:
             raise VerificationError("benchmark results must be an object")
         successful = results.get("successful_requests")
         failed = results.get("failed_requests")
-        if successful is not None and successful != 5:
+        if type(successful) is not int or successful != 5:
             raise VerificationError(
                 f"benchmark has {successful!r} successful requests, expected 5"
             )
-        if failed is not None and failed != 0:
+        if type(failed) is not int or failed != 0:
             raise VerificationError(f"benchmark reports {failed!r} failed requests")
         total = DeliveryVerifier._first_positive(
             results, ("total_duration_seconds", "total_s", "latency")
@@ -1241,7 +1292,22 @@ class DeliveryVerifier:
             raise VerificationError(
                 "benchmark lacks positive latency or peak-memory metrics"
             )
-        return {"total_s": total, "peak_memory_mib": peak}
+        mean = total / successful
+        reported_mean = DeliveryVerifier._first_positive(
+            results, ("latency_per_request_seconds",)
+        )
+        if reported_mean is not None and not math.isclose(
+            reported_mean, mean, rel_tol=1e-9, abs_tol=1e-9
+        ):
+            raise VerificationError(
+                "benchmark per-request latency is inconsistent with total/count"
+            )
+        return {
+            "mean_e2e_s": mean,
+            "workload_total_s": total,
+            "request_count": successful,
+            "peak_memory_mib": peak,
+        }
 
     @staticmethod
     def _required_media(run_dir: Path, artifacts: Sequence[Path]) -> Path:

--- a/sgl-engine-sglang-diffusion/techniques/cache.md
+++ b/sgl-engine-sglang-diffusion/techniques/cache.md
@@ -40,8 +40,8 @@ and failure mode.
 Compare quality only at matched measured end-to-end time:
 
 ```text
-time_ratio = candidate_total_s / frozen_baseline_total_s
-speedup = frozen_baseline_total_s / candidate_total_s
+time_ratio = candidate_mean_e2e_s / frozen_baseline_mean_e2e_s
+speedup = frozen_baseline_mean_e2e_s / candidate_mean_e2e_s
 ```
 
 Two family points are matched only when their measured `time_ratio` differs by

--- a/sgl-engine-sglang-diffusion/tests/test_artifacts.py
+++ b/sgl-engine-sglang-diffusion/tests/test_artifacts.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from sgl_engine_sglang_diffusion.artifacts import SCHEMA_MODELS, write_schemas
-from sgl_engine_sglang_diffusion.models import Delivery
+from sgl_engine_sglang_diffusion.models import BaselineRecord, Delivery
 
 
 EXPECTED_SCHEMAS = {
@@ -43,6 +43,28 @@ def test_delivery_rejects_unknown_fields() -> None:
                 "frontier_points": [],
                 "pareto_assessment": "empty",
                 "fabricated": True,
+            }
+        )
+
+
+def test_baseline_rejects_ambiguous_or_inconsistent_timing() -> None:
+    common = {
+        "model_id": "test/model",
+        "peak_memory_mib": 1024.0,
+        "timing_scope": "frozen_e2e",
+        "run_dir": "baseline/run",
+        "baseline_frames": "baseline/frames",
+        "sglang_commit": "a" * 40,
+    }
+    with pytest.raises(ValidationError):
+        BaselineRecord.model_validate({**common, "total_s": 50.0})
+    with pytest.raises(ValidationError, match=r"mean_e2e_s \* request_count"):
+        BaselineRecord.model_validate(
+            {
+                **common,
+                "mean_e2e_s": 10.0,
+                "workload_total_s": 49.0,
+                "request_count": 5,
             }
         )
 

--- a/sgl-engine-sglang-diffusion/tests/test_controller.py
+++ b/sgl-engine-sglang-diffusion/tests/test_controller.py
@@ -106,9 +106,11 @@ def test_valid_lower_bound_certificate_can_end_campaign(tmp_path: Path) -> None:
     campaign = tmp_path / "campaign"
     campaign.mkdir()
     baseline = {
-        "schema_version": 1,
+        "schema_version": 2,
         "model_id": goal.model.id,
-        "total_s": 10.0,
+        "mean_e2e_s": 10.0,
+        "workload_total_s": 50.0,
+        "request_count": 5,
         "peak_memory_mib": 1.0,
         "timing_scope": goal.workload.timing_scope,
         "run_dir": str(campaign / "baseline/run"),

--- a/sgl-engine-sglang-diffusion/tests/test_driver.py
+++ b/sgl-engine-sglang-diffusion/tests/test_driver.py
@@ -78,7 +78,8 @@ class FakeRunner:
                     "results": {
                         "successful_requests": 5,
                         "failed_requests": 0,
-                        "total_duration_seconds": 1.0,
+                        "total_duration_seconds": 400.0,
+                        "latency_per_request_seconds": 80.0,
                         "peak_memory_mb": 1024.0,
                     }
                 }
@@ -154,7 +155,9 @@ def test_baseline_is_frozen_once(tmp_path: Path) -> None:
     campaign = tmp_path / "campaign"
 
     record = baseline.freeze(goal, campaign, sglang_commit=COMMIT)
-    assert record.total_s == 1.0
+    assert record.mean_e2e_s == 80.0
+    assert record.workload_total_s == 400.0
+    assert record.request_count == 5
     assert len(list(record.baseline_frames.glob("prompt-*"))) == 5
     assert runner.calls == 1
 
@@ -207,6 +210,82 @@ def test_normalizer_rejects_failed_requests(tmp_path: Path) -> None:
         + "\n"
     )
     with pytest.raises(DriverError, match="successful requests"):
+        SGLangDiffusionDriver.normalize_output(
+            result, timing_scope="end_to_end", expected_requests=5
+        )
+
+
+def test_normalizer_uses_per_request_mean_as_authoritative_latency(
+    tmp_path: Path,
+) -> None:
+    result = tmp_path / "benchmark.jsonl"
+    result.write_text(
+        json.dumps(
+            {
+                "results": {
+                    "successful_requests": 5,
+                    "failed_requests": 0,
+                    "total_duration_seconds": 400.0,
+                    "latency_per_request_seconds": 80.0,
+                    "peak_memory_mb": 1024.0,
+                }
+            }
+        )
+        + "\n"
+    )
+
+    normalized = SGLangDiffusionDriver.normalize_output(
+        result, timing_scope="end_to_end", expected_requests=5
+    )
+
+    assert normalized["schema_version"] == 2
+    assert normalized["mean_e2e_s"] == 80.0
+    assert normalized["workload_total_s"] == 400.0
+    assert normalized["request_count"] == 5
+    assert "total_s" not in normalized
+
+
+def test_normalizer_rejects_inconsistent_reported_request_mean(
+    tmp_path: Path,
+) -> None:
+    result = tmp_path / "benchmark.jsonl"
+    result.write_text(
+        json.dumps(
+            {
+                "results": {
+                    "successful_requests": 5,
+                    "failed_requests": 0,
+                    "total_duration_seconds": 400.0,
+                    "latency_per_request_seconds": 79.0,
+                    "peak_memory_mb": 1024.0,
+                }
+            }
+        )
+        + "\n"
+    )
+
+    with pytest.raises(DriverError, match="per-request latency disagrees"):
+        SGLangDiffusionDriver.normalize_output(
+            result, timing_scope="end_to_end", expected_requests=5
+        )
+
+
+def test_normalizer_requires_successful_request_count(tmp_path: Path) -> None:
+    result = tmp_path / "benchmark.jsonl"
+    result.write_text(
+        json.dumps(
+            {
+                "results": {
+                    "failed_requests": 0,
+                    "total_duration_seconds": 400.0,
+                    "peak_memory_mb": 1024.0,
+                }
+            }
+        )
+        + "\n"
+    )
+
+    with pytest.raises(DriverError, match="successful request count"):
         SGLangDiffusionDriver.normalize_output(
             result, timing_scope="end_to_end", expected_requests=5
         )

--- a/sgl-engine-sglang-diffusion/tests/test_final_quality.py
+++ b/sgl-engine-sglang-diffusion/tests/test_final_quality.py
@@ -94,7 +94,9 @@ def _hooks_and_baseline(tmp_path: Path) -> tuple[FileCampaignHooks, BaselineReco
         (run_dir / f"prompt-{index}.png").write_bytes(b"image")
     baseline = BaselineRecord(
         model_id=goal.model.id,
-        total_s=10.0,
+        mean_e2e_s=10.0,
+        workload_total_s=50.0,
+        request_count=5,
         peak_memory_mib=100.0,
         timing_scope=goal.workload.timing_scope,
         run_dir=run_dir,

--- a/sgl-engine-sglang-diffusion/tests/test_integration_flow.py
+++ b/sgl-engine-sglang-diffusion/tests/test_integration_flow.py
@@ -101,11 +101,17 @@ class FakeDriver:
         receipt = run_dir / "COMMAND.json"
         output_file.parent.mkdir(parents=True)
         media_dir.mkdir()
-        output_file.write_text('{"results": {"total_s": 5.0}}\n')
+        output_file.write_text(
+            '{"results": {"successful_requests": 5, "failed_requests": 0, '
+            '"total_duration_seconds": 25.0, "latency_per_request_seconds": 5.0}}\n'
+        )
         normalized_file.write_text(
             json.dumps(
                 {
-                    "total_s": 5.0,
+                    "schema_version": 2,
+                    "mean_e2e_s": 5.0,
+                    "workload_total_s": 25.0,
+                    "request_count": 5,
                     "peak_memory_mib": 80.0,
                     "timing_scope": goal.workload.timing_scope,
                 }
@@ -127,7 +133,10 @@ class FakeDriver:
             media_dir=media_dir,
             command_receipt=receipt,
             normalized={
-                "total_s": 5.0,
+                "schema_version": 2,
+                "mean_e2e_s": 5.0,
+                "workload_total_s": 25.0,
+                "request_count": 5,
                 "peak_memory_mib": 80.0,
                 "timing_scope": goal.workload.timing_scope,
             },
@@ -229,7 +238,9 @@ def _goal(prompt_file: Path) -> CampaignGoal:
 def _baseline(tmp_path: Path, base: str) -> BaselineRecord:
     return BaselineRecord(
         model_id="fake/model",
-        total_s=10.0,
+        mean_e2e_s=10.0,
+        workload_total_s=50.0,
+        request_count=5,
         peak_memory_mib=100.0,
         timing_scope="load_excluded_end_to_end",
         run_dir=tmp_path / "baseline-run",

--- a/sgl-engine-sglang-diffusion/tests/test_orchestration.py
+++ b/sgl-engine-sglang-diffusion/tests/test_orchestration.py
@@ -63,7 +63,8 @@ def _prompt() -> ExecutorPrompt:
         ),
         baseline=PromptSection(
             "Frozen baseline",
-            '{"total_s": 10.0}\n',
+            '{"schema_version": 2, "mean_e2e_s": 10.0, '
+            '"workload_total_s": 50.0, "request_count": 5}\n',
             "campaign:BASELINE.json",
         ),
         search_state={"round": 1, "frontier": []},

--- a/sgl-engine-sglang-diffusion/tests/test_progress.py
+++ b/sgl-engine-sglang-diffusion/tests/test_progress.py
@@ -83,7 +83,16 @@ def test_progress_reports_tokens_techniques_and_nonadditive_stack(
     )
     integrated = campaign / "integration" / "1" / "attempt-001"
     integrated.mkdir(parents=True)
-    (campaign / "BASELINE.json").write_text(json.dumps({"total_s": 10.0}))
+    (campaign / "BASELINE.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "mean_e2e_s": 10.0,
+                "workload_total_s": 50.0,
+                "request_count": 5,
+            }
+        )
+    )
     (integrated / "INTEGRATED-DELIVERY.json").write_text(
         json.dumps(
             {
@@ -91,7 +100,9 @@ def test_progress_reports_tokens_techniques_and_nonadditive_stack(
                     {
                         "performance": {
                             "speedup": 1.68,
-                            "candidate_total_s": 5.95238095,
+                            "candidate_mean_e2e_s": 5.95238095,
+                            "candidate_workload_total_s": 29.76190475,
+                            "request_count": 5,
                         },
                         "implementation_manifest": {
                             "recipe": {"techniques": ["kernel"]}
@@ -134,8 +145,12 @@ def test_progress_reports_tokens_techniques_and_nonadditive_stack(
     assert progress["best_verified_speedup"] == 1.68
     assert progress["performance_progress"] == 0.68
     assert progress["integrated_stack_speedup"] == 1.68
-    assert progress["baseline_total_s"] == 10.0
-    assert progress["integrated_total_s"] == 5.95238095
+    assert progress["baseline_mean_e2e_s"] == 10.0
+    assert progress["baseline_workload_total_s"] == 50.0
+    assert progress["baseline_request_count"] == 5
+    assert progress["integrated_mean_e2e_s"] == 5.95238095
+    assert progress["integrated_workload_total_s"] == 29.76190475
+    assert progress["integrated_request_count"] == 5
     assert progress["tokens"]["total_tokens"] == 120
     assert progress["tokens"]["by_role"] == {"executor": 120}
     assert progress["tokens"]["by_technique"] == {"kernel": 120}
@@ -153,5 +168,8 @@ def test_progress_reports_tokens_techniques_and_nonadditive_stack(
     assert "120 total" in rendered
     assert "executor=120" in rendered
     assert "integrated stack" in rendered
-    assert "10.0000s baseline" in rendered
+    assert "10.0000s/request baseline" in rendered
+    assert "5.9524s/request integrated" in rendered
+    assert "50.0000s/5 requests baseline" in rendered
+    assert "29.7619s/5 requests integrated" in rendered
     assert (campaign / "PROGRESS.json").is_file()

--- a/sgl-engine-sglang-diffusion/tests/test_runtime_e2e.py
+++ b/sgl-engine-sglang-diffusion/tests/test_runtime_e2e.py
@@ -45,7 +45,7 @@ run_dir = output_file.parent.parent
 output_file.parent.mkdir(parents=True, exist_ok=True)
 media.mkdir(parents=True, exist_ok=True)
 optimized = (checkout / "python/sglang/kernels/agent/runtime.py").is_file()
-total = 9.0 if optimized else 10.0
+total = 45.0 if optimized else 50.0
 result = {
     "results": {
         "successful_requests": 5,
@@ -385,7 +385,8 @@ raw = {
     "results": {
         "successful_requests": 5,
         "failed_requests": 0,
-        "total_duration_seconds": 9.0,
+        "total_duration_seconds": 45.0,
+        "latency_per_request_seconds": 9.0,
         "peak_memory_mb": 90.0,
     }
 }
@@ -395,8 +396,10 @@ for index in range(5):
         b"candidate-" + bytes([index])
     )
 (run_dir / "PERFORMANCE.json").write_text(json.dumps({
-    "schema_version": 1,
-    "total_s": 9.0,
+    "schema_version": 2,
+    "mean_e2e_s": 9.0,
+    "workload_total_s": 45.0,
+    "request_count": 5,
     "peak_memory_mib": 90.0,
     "timing_scope": "load_excluded_end_to_end",
 }))
@@ -491,7 +494,12 @@ delivery = {
     "status": "complete",
     "component": "kernel",
     "model_id": "fake-model",
-    "baseline": {"total_s": 10.0},
+    "baseline": {
+        "schema_version": 2,
+        "mean_e2e_s": 10.0,
+        "workload_total_s": 50.0,
+        "request_count": 5,
+    },
     "frontier_points": [{
         "candidate_id": "fake-kernel",
         "run_dir": str(run_dir),
@@ -501,9 +509,13 @@ delivery = {
         },
         "implementation_manifest": implementation,
         "performance": {
+            "schema_version": 2,
             "frontier_axis": "latency",
-            "baseline_total_s": 10.0,
-            "candidate_total_s": reported_total,
+            "baseline_mean_e2e_s": 10.0,
+            "candidate_mean_e2e_s": reported_total,
+            "baseline_workload_total_s": 50.0,
+            "candidate_workload_total_s": reported_total * 5,
+            "request_count": 5,
             "speedup": 10.0 / reported_total,
         },
         "quality": {

--- a/sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py
+++ b/sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py
@@ -63,7 +63,10 @@ def test_executor_prompt_injects_only_active_lane_history_rules(
     (campaign / "KNOWLEDGE.json").write_text(
         json.dumps({"schema_version": 1, "snapshots": {}})
     )
-    (campaign / "BASELINE.json").write_text('{"total_s": 10.0}\n')
+    (campaign / "BASELINE.json").write_text(
+        '{"schema_version": 2, "mean_e2e_s": 10.0, '
+        '"workload_total_s": 50.0, "request_count": 5}\n'
+    )
     (campaign / "profiles/0/PROFILE-DIGEST.json").write_text(
         '{"profile": "bound"}\n'
     )

--- a/sgl-engine-sglang-diffusion/tests/test_verifier.py
+++ b/sgl-engine-sglang-diffusion/tests/test_verifier.py
@@ -86,10 +86,12 @@ def evidence(tmp_path: Path) -> dict[str, Any]:
 
     run_dir.mkdir(parents=True)
     performance = {
-        "schema_version": 1,
+        "schema_version": 2,
         "candidate_id": "candidate-1",
         "run_id": "run-1",
-        "total_s": 5.0,
+        "mean_e2e_s": 5.0,
+        "workload_total_s": 25.0,
+        "request_count": 5,
         "peak_memory_mib": 900.0,
         "timing_scope": "frozen_e2e",
         "fallback_count": 0,
@@ -103,7 +105,8 @@ def evidence(tmp_path: Path) -> dict[str, Any]:
                 "results": {
                     "successful_requests": 5,
                     "failed_requests": 0,
-                    "total_s": 5.0,
+                    "total_duration_seconds": 25.0,
+                    "latency_per_request_seconds": 5.0,
                     "peak_memory_mib": 900.0,
                 }
             }
@@ -269,9 +272,13 @@ def evidence(tmp_path: Path) -> dict[str, Any]:
         "activation": {"enable_agent_kernel": True},
         "implementation_manifest": manifest,
         "performance": {
+            "schema_version": 2,
             "frontier_axis": "latency",
-            "baseline_total_s": 10.0,
-            "candidate_total_s": 5.0,
+            "baseline_mean_e2e_s": 10.0,
+            "candidate_mean_e2e_s": 5.0,
+            "baseline_workload_total_s": 50.0,
+            "candidate_workload_total_s": 25.0,
+            "request_count": 5,
             "speedup": 2.0,
         },
         # Deliberately non-null: lossless verification must ignore LPIPS movement.
@@ -290,7 +297,12 @@ def evidence(tmp_path: Path) -> dict[str, Any]:
         "status": "complete",
         "component": "kernel",
         "model_id": "test/model",
-        "baseline": {"total_s": 10.0},
+        "baseline": {
+            "schema_version": 2,
+            "mean_e2e_s": 10.0,
+            "workload_total_s": 50.0,
+            "request_count": 5,
+        },
         "frontier_points": [point],
         "pareto_assessment": "latency improvement",
     }
@@ -298,7 +310,9 @@ def evidence(tmp_path: Path) -> dict[str, Any]:
     delivery_path.write_text(json.dumps(delivery))
     baseline = BaselineRecord(
         model_id="test/model",
-        total_s=10.0,
+        mean_e2e_s=10.0,
+        workload_total_s=50.0,
+        request_count=5,
         peak_memory_mib=1024.0,
         timing_scope="frozen_e2e",
         run_dir=baseline_run,
@@ -487,11 +501,13 @@ def test_raw_benchmark_must_match_normalized_performance(
 ) -> None:
     performance_path = evidence["run_dir"] / "PERFORMANCE.json"
     performance = json.loads(performance_path.read_text())
-    performance["total_s"] = 4.0
+    performance["mean_e2e_s"] = 4.0
+    performance["workload_total_s"] = 20.0
     performance_path.write_text(json.dumps(performance))
     delivery = deepcopy(evidence["delivery"])
     point = delivery["frontier_points"][0]["performance"]
-    point["candidate_total_s"] = 4.0
+    point["candidate_mean_e2e_s"] = 4.0
+    point["candidate_workload_total_s"] = 20.0
     point["speedup"] = 2.5
     result = make_verifier(evidence, registry).verify(
         write_delivery(evidence, delivery),

--- a/skills/sglang-diffusion-auto-optimize/SKILL.md
+++ b/skills/sglang-diffusion-auto-optimize/SKILL.md
@@ -81,6 +81,12 @@ Do not run the complete baseline as a separate preflight. Check paths, prompt
 count, command syntax, benchmark `--help`, and imports only. The controller owns
 the single authoritative baseline run.
 
+For that baseline and every later candidate, the controller independently
+computes the arithmetic mean E2E seconds per successful request from the exact
+five-request workload total. This mean is the only optimization, speedup, and
+target-completion basis. The five-request total is retained separately for
+audit and is never presented as single-request latency.
+
 ## Phase 2: Bootstrap The Controller
 
 Prefer the controller shipped beside this skill:
@@ -192,6 +198,8 @@ updates at meaningful transitions or at least once per long-running interval.
 Do not reinterpret an executor's microbenchmark claim as progress. Report only:
 
 - frozen-baseline and integrated full-workload end-to-end speedup;
+- frozen-baseline and integrated arithmetic-mean E2E seconds per successful
+  request, with the five-request workload total shown separately for audit;
 - best independently verified isolated end-to-end speedup by technique;
 - correctness/quality gate result and failure reason;
 - integrated-stack speedup separately from isolated gains;
@@ -233,7 +241,8 @@ checkable lower-bound certificate.
 For `TARGET_REACHED`, report:
 
 - locked SGLang commit and exact workload;
-- baseline, final latency, and measured speedup;
+- baseline and final arithmetic-mean E2E seconds per successful request,
+  five-request audit totals, and measured speedup;
 - each technique's isolated measurement and gate result;
 - integrated stack result;
 - total exact tokens by role/technique when available;

--- a/skills/sglang-diffusion-auto-optimize/references/progress-contract.md
+++ b/skills/sglang-diffusion-auto-optimize/references/progress-contract.md
@@ -14,6 +14,19 @@ performance_progress =
 integrated full-workload result. Projected kernel gains and unverified
 executor claims do not move the bar.
 
+Every baseline, isolated candidate, and integrated candidate is optimized and
+compared using the arithmetic mean E2E seconds per successful request:
+
+```text
+mean_e2e_s = workload_total_s / request_count
+speedup = baseline_mean_e2e_s / candidate_mean_e2e_s
+```
+
+`request_count` must be exactly five and failed requests must be zero. Keep
+`workload_total_s` as a separately labelled audit metric. Never treat the
+five-request total as a single-request latency or expose ambiguous `total_s`
+fields in new campaign artifacts.
+
 ## Search
 
 Search progress is consumed routed-technique rounds divided by their total


### PR DESCRIPTION
## Summary

- make the arithmetic mean E2E time per successful request the authoritative baseline, candidate, integration, progress, and completion metric
- retain the complete five-request workload duration and request count as separately named audit evidence
- independently recompute and cross-check mean/count/total in the controller and deterministic verifier, rejecting ambiguous v1 timing artifacts
- update schemas, executor/master contracts, skill guidance, progress output, and cache formulas

## Why

The previous `total_s` contract could represent the full five-prompt workload while being displayed and optimized as latency. That made results incomparable with runs reporting the per-request average. This change makes the unit and aggregation explicit and keeps every speedup calculation on the single-request arithmetic mean.

## Validation

- `pytest -q` — 155 passed
- `ruff check src tests`
- `python3 -m compileall -q src tests`
- `pre-commit run --all-files`
- `python3 -m pip wheel . --no-deps -w /tmp/sgl-mean-e2e-wheel`
