### PR TITLE
fix(diffusion): recover healthy autonomous optimization loops

### DIFF
--- a/docs/superpowers/plans/2026-08-01-diffusion-optimization-loop-reliability.md
+++ b/docs/superpowers/plans/2026-08-01-diffusion-optimization-loop-reliability.md
@@ -1,0 +1,323 @@
+# Diffusion Optimization Loop Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make unattended diffusion optimization resume one Codex session, preflight exact evidence contracts, recover complete KDA knowledge, bound broken retries, and reach high-leverage lanes without weakening verification.
+
+**Architecture:** Keep `sgl-diffusion-engine` as the sole state machine. Add transactional source/knowledge validation, a controller-generated delivery contract consumed by a shared static verifier, durable Codex thread IDs, authenticated-measurement accounting, epoch-local lane deferral, and target-aware routing.
+
+**Tech Stack:** Python 3.11, Pydantic v2, JSON/JSONL, Git worktrees and submodules, Codex CLI, pytest, ruff.
+
+---
+
+### Task 1: Preserve the campaign fixes already proven necessary
+
+**Files:**
+
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/request.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_integration_flow.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_orchestration.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_request.py`
+
+- [ ] **Step 1: Apply the four isolated campaign fixes**
+
+Cherry-pick commits `ddb4832`, `a17be8f`, `e28a968`, and `7ca5a07` from the
+existing controller-fix branch. They provide process-local integration and
+Executor identities, writable non-interactive Codex execution, and complete
+H3/backend/batch/topology workload freezing.
+
+- [ ] **Step 2: Run their focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_integration_flow.py tests/test_orchestration.py tests/test_request.py
+```
+
+Expected: all tests pass with global Git configuration disabled in the identity
+regressions.
+
+### Task 2: Make KDA source material complete before snapshotting
+
+**Files:**
+
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/sources.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/knowledge.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_sources.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_knowledge.py`
+
+- [ ] **Step 1: Write failing gitlink and snapshot tests**
+
+Create a local parent repository with a pinned local submodule. Assert that
+`create_worktree(..., initialize_submodules=True, required_submodules=(...))`
+checks out the gitlink commit and rejects a missing required path. Add snapshot
+tests that reject zero entries, a missing required prefix, a missing copied
+reference, and a changed reference digest.
+
+- [ ] **Step 2: Implement explicit submodule materialization**
+
+Add a method equivalent to:
+
+```python
+def ensure_submodules(self, worktree: Path, required: Sequence[str]) -> None:
+    run(["git", "submodule", "sync", "--recursive"], cwd=worktree)
+    run(["git", "submodule", "update", "--init", "--recursive"], cwd=worktree)
+    for relative in required:
+        expected = gitlink_commit(worktree, relative)
+        actual = run(["git", "rev-parse", "HEAD"], cwd=worktree / relative)
+        if actual.stdout.strip() != expected:
+            raise RuntimeError("required submodule is not at its pinned gitlink")
+```
+
+Validate safe relative paths before invoking Git.
+
+- [ ] **Step 3: Build and validate snapshots transactionally**
+
+Build references and `index.json` in a sibling staging directory. Require at
+least one entry and each configured KDA prefix. Verify each copied file's
+`reference_sha256` before publishing or reusing the snapshot. Runtime preserves
+an invalid existing output under `knowledge/rejected/` and rebuilds it.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sources.py tests/test_knowledge.py
+```
+
+Expected: complete pinned submodules and snapshot reuse pass; incomplete
+material fails closed or is recovered by runtime.
+
+### Task 3: Generate an executable delivery contract and shared preflight
+
+**Files:**
+
+- Create: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/delivery_contract.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/cli.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_cli.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_orchestration.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_verifier.py`
+
+- [ ] **Step 1: Write contract-generation failures**
+
+Assert that the contract contains `Delivery.model_json_schema()`, the active
+technique evidence schema, exact performance/command requirements, baseline and
+profile hashes, and only pinned KernelWiki reference paths plus matching
+digests. An empty KernelWiki set must prevent a kernel Executor from spawning.
+
+- [ ] **Step 2: Add static verifier mode**
+
+Extend `DeliveryVerifier.verify` with `independent_gates: bool = True`. Static
+mode runs every schema, containment, command, benchmark, performance, source,
+engagement, equivalence, and technique-evidence check, but skips the external
+method auditor and quality evaluator. Authoritative calls keep the default.
+
+- [ ] **Step 3: Add the CLI preflight**
+
+Implement:
+
+```text
+sgl-diffusion-engine preflight-delivery \
+  --campaign <campaign> --technique <lane> \
+  --executor-worktree <worktree> --delivery <DELIVERY.json>
+```
+
+Print JSON findings and return `0` only when static verification accepts the
+bundle.
+
+- [ ] **Step 4: Inject the controller-owned contract**
+
+Write `DELIVERY-CONTRACT.json` under the Executor root before launch and add it
+as a hashed prompt section before search state. Include the exact preflight
+argv. Keep the file outside the candidate worktree so it cannot enter the
+candidate commit accidentally.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_cli.py tests/test_orchestration.py tests/test_verifier.py
+```
+
+Expected: a valid fixture passes preflight and authoritative verification;
+invalid KernelWiki paths fail identically in both modes.
+
+### Task 4: Resume the same Codex thread
+
+**Files:**
+
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_orchestration.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_telemetry.py`
+
+- [ ] **Step 1: Write fake Codex JSONL tests**
+
+Emit:
+
+```json
+{"type":"thread.started","thread_id":"67e55044-10b1-426f-9247-bb680e5fe0c8"}
+```
+
+Assert persistence to `SESSION.json`, rejection of conflicting IDs, and argv
+construction as `codex exec resume <id> <prompt>` on attempt two.
+
+- [ ] **Step 2: Implement thread extraction and durable identity**
+
+Parse only `thread.started` JSON objects from the attempt stdout. Persist the
+thread ID atomically with the Executor identity. Do not use `--last`, because
+another campaign may have started a newer thread.
+
+- [ ] **Step 3: Use compact feedback turns**
+
+For Codex resume, write a prompt containing the new finding set, delivery path,
+and preflight command. Do not concatenate the base prompt or earlier feedback.
+Retain full replay for non-Codex commands that cannot resume sessions.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_orchestration.py tests/test_telemetry.py
+```
+
+Expected: the first and second invocation share one thread ID and token ledgers
+continue to record each turn separately.
+
+### Task 5: Count real measurements and bound broken retries
+
+**Files:**
+
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_verifier.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_progress.py`
+
+- [ ] **Step 1: Write authenticated malformed-delivery tests**
+
+Start with a valid full run and break only `KERNEL-EVIDENCE.json`. Assert that
+verification rejects the candidate but exposes one authenticated measurement.
+Break the frozen command or benchmark count and assert that no authenticated
+measurement is exposed.
+
+- [ ] **Step 2: Record measurement identity independently of acceptance**
+
+Add an `AuthenticatedMeasurement` result containing candidate ID, run path,
+mean, workload total, request count, peak memory, and speedup. Record its round
+once even when later evidence or audit findings reject the candidate.
+
+- [ ] **Step 3: Add epoch-local lane deferral**
+
+Count prior `executor_resumed` events by failure signature. On the third same
+signature or sixth total attempt, write `search/<epoch>/DEFERRED-LANES.json`,
+clear the active lane, and select the next unresolved non-deferred route.
+Deferred lanes never become coverage dispositions.
+
+- [ ] **Step 4: Make progress reflect durable scheduler state**
+
+Read `EXECUTORS.json`, `TECHNIQUE-DISPOSITIONS.json`, and
+`DEFERRED-LANES.json`. Mark only `active_technique` as `running`; use
+`attempted`, `deferred`, and `dispositioned` for the rest.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_verifier.py tests/test_runtime_scheduler.py tests/test_progress.py
+```
+
+Expected: evidence repair consumes the real GPU round once, repeated signatures
+advance the lane queue, and progress has exactly one running row.
+
+### Task 6: Route large targets toward high-leverage methods
+
+**Files:**
+
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/profiler.py`
+- Modify: `sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py`
+- Modify: `sgl-engine-sglang-diffusion/techniques/kernel.md`
+- Modify: `skills/sglang-diffusion-auto-optimize/SKILL.md`
+- Modify: `skills/sglang-diffusion-auto-optimize/references/progress-contract.md`
+- Test: `sgl-engine-sglang-diffusion/tests/test_profiler.py`
+- Test: `sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py`
+
+- [ ] **Step 1: Write target-aware routing tests**
+
+Assert the original `residency, kernel` order for lossless-only campaigns and
+modest targets. For `allow_quality_gated=true` and target at least `3.0`, assert
+`residency, cache, pisa, quantization, token_pruning, kernel`, plus a recorded
+`large-gap-quality-first-v1` policy.
+
+- [ ] **Step 2: Pass target and current gap into routing/search state**
+
+Add target speedup to `TechniqueRouter.route`. Include target, best verified
+speedup, remaining multiplier, and route policy in `ROUTES.json` and each
+Executor's search state.
+
+- [ ] **Step 3: Require screening and production wiring**
+
+Update the kernel contract and skill so a candidate first runs a targeted
+correctness/microbenchmark screen. Existing flags may be controls, but a patch
+candidate must change production-consumed source and prove positive engagement;
+an inert JSON file cannot stand in for the activation that produced a result.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_profiler.py tests/test_runtime_scheduler.py
+```
+
+Expected: a 5x quality-gated campaign reaches cache before kernel while all
+required lanes remain scheduled.
+
+### Task 7: Validate and publish
+
+**Files:**
+
+- Validate: `skills/sglang-diffusion-auto-optimize/`
+- Validate: `sgl-engine-sglang-diffusion/`
+
+- [ ] **Step 1: Run formatting and the complete suite**
+
+Run:
+
+```bash
+cd sgl-engine-sglang-diffusion
+python -m ruff check src tests
+pytest -q
+```
+
+Expected: no lint errors and the full test suite passes.
+
+- [ ] **Step 2: Validate the updated skill**
+
+Run:
+
+```bash
+python /Users/bbuf/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  skills/sglang-diffusion-auto-optimize
+```
+
+Expected: `Skill is valid!`
+
+- [ ] **Step 3: Review, commit, push, and open a draft PR**
+
+Stage only the files listed by this plan, commit with a terse reliability-fix
+message, push `agent/repair-diffusion-optimization-loop`, and create a draft PR
+against `BBuf/AI-Infra-Auto-Driven-SKILLS:main`. The PR body must describe root
+causes, behavior changes, compatibility, and exact validation commands.

--- a/docs/superpowers/specs/2026-08-01-diffusion-optimization-loop-reliability-design.md
+++ b/docs/superpowers/specs/2026-08-01-diffusion-optimization-loop-reliability-design.md
@@ -1,0 +1,198 @@
+# Diffusion Optimization Loop Reliability Design
+
+## Purpose
+
+Repair the unattended `sgl-diffusion-engine` loop after the MiniMax-H3 campaign
+showed that valid GPU work could be hidden behind repeated delivery-protocol
+failures. The controller must preserve strict verification while making every
+contract executable, resuming the same Codex thread, bounding repeated
+infrastructure failures, and allowing high-leverage lanes to proceed.
+
+The public repository contains two separate skills. `sglang-humanize-review`
+reviews SGLang changes; `sglang-diffusion-auto-optimize` owns this optimization
+flow. The implementation and user-facing changes therefore belong to the
+diffusion skill and its adjacent Python controller.
+
+## Success Criteria
+
+1. KDA-Pilot worktrees initialize the exact pinned submodule commits for
+   KernelWiki, NCU reporting, and warp-specialization reporting before the
+   knowledge snapshot is built.
+2. A knowledge snapshot is non-empty, satisfies required path families, and
+   revalidates every copied file and digest when reused. An incomplete cached
+   snapshot is preserved for audit and rebuilt.
+3. Every Executor receives a controller-generated delivery contract containing
+   exact schemas, required artifacts, profile and baseline bindings, and valid
+   pinned KernelWiki citation paths and hashes.
+4. Executors can run the same structural verifier locally before returning a
+   delivery. Independent method and quality gates remain controller-owned and
+   run only during authoritative verification.
+5. `codex exec` attempts persist the `thread.started` ID. Feedback uses
+   `codex exec resume <thread-id>` with a compact turn prompt rather than
+   starting another conversation with the complete original prompt.
+6. Candidate worktrees receive process-local Git identities and a writable
+   non-interactive Codex sandbox without mutating global configuration.
+7. The exact H3/backend/batch/shape/parallel workload is frozen, and
+   integration cherry-picks have a process-local committer identity.
+8. A structurally flawed delivery that nevertheless contains an authenticated
+   full frozen-workload measurement consumes one scientific round. Duplicate
+   measurements remain idempotent.
+9. The same verifier failure may be resumed at most three times and one
+   Executor generation at most six times. A repeatedly broken lane is deferred
+   for the epoch so other lanes run; it is not falsely declared exhausted.
+10. For large quality-gated targets, routing begins with residency, then moves
+    through high-leverage algorithmic lanes before the kernel tail. Low-impact
+    candidates are screened with targeted tests before a costly five-prompt
+    run.
+11. Progress reports only the manifest's active lane as running, and exposes
+    deferred and dispositioned lanes accurately.
+
+## Approaches Considered
+
+### 1. Controller-owned contracts and bounded recovery
+
+Generate the contract from the same Pydantic models and pinned campaign
+artifacts used by the verifier. Add a static preflight command, persist Codex
+thread identity, and defer a lane after bounded repeated failures.
+
+This is the selected approach. It removes duplicated human interpretation
+without weakening scientific or quality gates, and it can be introduced
+without replacing the existing campaign state machine.
+
+### 2. Prompt-only clarification
+
+Add more examples and warnings to `executor.md`. This is small but leaves
+schema drift, invalid knowledge paths, fresh Codex conversations, and infinite
+retry behavior intact. The failed campaign already demonstrated that prose is
+not a reliable protocol boundary.
+
+### 3. Move all candidate execution out of Executors
+
+Make Executors submit only source patches and have the outer controller create
+all run artifacts. This provides the strongest ownership boundary, but it is a
+larger protocol migration that would invalidate current delivery producers.
+The selected design first makes the existing boundary deterministic and
+machine-checkable.
+
+## Architecture
+
+```text
+pinned source locks
+  -> submodule-complete immutable worktrees
+  -> validated knowledge snapshots
+  -> Controller delivery contract
+  -> Codex Executor thread (initial turn)
+       -> targeted screen
+       -> full frozen workload
+       -> static preflight
+  -> same Codex thread (feedback turns)
+  -> authoritative verifier + independent gates
+  -> candidate registry / next gap-aware lane
+```
+
+The Controller remains the sole campaign owner. The static preflight shares
+schema, path, command, performance, kernel/residency evidence, and source-diff
+checks with the authoritative verifier. It deliberately skips independent
+method review and quality evaluation, so an Executor cannot self-approve.
+
+## Source and Knowledge Integrity
+
+`SourceManager.create_worktree` gains an explicit submodule mode. Runtime uses
+it only for KDA-Pilot and requires these paths:
+
+- `external/KernelWiki`;
+- `external/ncu-report-skill`;
+- `external/warp-specialization-report-skill`.
+
+Each required path must be a gitlink at the locked parent commit, must be
+checked out at that gitlink commit, and must contain files. Knowledge sync is
+transactional: build in a staging directory, validate required prefixes and
+all reference hashes, then publish the index. Reuse repeats the validation.
+Invalid legacy output is renamed under a campaign-owned rejected directory
+before reconstruction, preserving audit evidence.
+
+## Delivery Contract and Preflight
+
+Before spawning an Executor, the runtime writes `DELIVERY-CONTRACT.json`
+outside the candidate worktree. It contains:
+
+- JSON schemas generated from the current delivery and technique evidence
+  models;
+- exact required artifact names and performance fields;
+- frozen baseline identity, timing scope, request count, command-template hash,
+  profile hash, and GPU inventory binding;
+- valid pinned KernelWiki reference paths with their reference digests;
+- the exact static-preflight argv for the assigned worktree and delivery.
+
+The assembled prompt includes this contract as a hashed, higher-precedence
+controller section. `sgl-diffusion-engine preflight-delivery` loads the same
+campaign baseline, registry, command template, and verifier implementation.
+It emits structured findings and exits non-zero until all static checks pass.
+The authoritative verifier subsequently repeats those checks and adds the
+independent method or quality gate.
+
+## Codex Session Continuity
+
+For a Codex command, the first JSONL stream must contain exactly one
+`thread.started` event with a non-empty thread ID. The manager persists it in
+`SESSION.json`, includes it in attempt manifests, and rejects conflicting IDs.
+
+Attempt one uses `codex exec`. Later attempts use:
+
+```text
+codex exec resume <thread-id> <compact-feedback-prompt>
+```
+
+The compact prompt contains only the new verifier findings, the durable
+delivery path, and the preflight command. The original contract and earlier
+reasoning stay in the Codex thread and in immutable campaign artifacts. Generic
+non-Codex agent commands retain the legacy full-prompt replay behavior.
+
+## Measurement Accounting and Recovery
+
+Verification results distinguish:
+
+- a fully accepted frontier point;
+- an authenticated full-workload measurement with later evidence/audit
+  findings; and
+- a pre-measurement or incomparable failure.
+
+The second category consumes a scientific round because the expensive frozen
+workload really ran. It never enters the candidate registry until every gate
+passes. Round identity binds technique, candidate, run directory, and normalized
+performance digest so a repaired resubmission cannot count twice.
+
+Repeated failure signatures are bounded per Executor. At the third occurrence,
+or the sixth total attempt, the lane is recorded in the epoch's deferral ledger
+and the scheduler advances to another unresolved lane. Deferred lanes are not
+coverage dispositions and cannot justify `SEARCH_SPACE_EXHAUSTED`. A later
+epoch gets a fresh Executor/thread; if no productive lane remains, the
+controller reports a precise infrastructure block instead of looping.
+
+## Gap-Aware Scheduling
+
+For lossless-only or modest targets, keep `residency -> kernel`. When quality
+gating is allowed and the target is at least 3x, route:
+
+```text
+residency -> cache -> pisa -> quantization -> token_pruning -> kernel
+```
+
+This preserves an early lossless residency result while preventing a marginal
+kernel/configuration candidate from blocking algorithmic methods capable of
+closing a large target gap. The route manifest records the selected policy and
+target. Executor search state includes the target, current verified best, and
+remaining multiplier. Technique prompts require a targeted screen before a
+full workload and require production-wired source changes rather than inert
+evidence/config files.
+
+## Testing
+
+Tests use local Git repositories and fake Codex JSONL streams. They cover
+gitlink checkout validation, stale snapshot rejection/rebuild, exact
+KernelWiki citation contracts, static preflight parity, thread ID persistence
+and resume argv, compact prompts, authenticated malformed-delivery round
+accounting, duplicate suppression, bounded deferral, high-target route order,
+accurate progress state, workload freezing, writable agent execution, and Git
+identity isolation. The full controller suite and skill validator must pass
+before publication.

--- a/sgl-engine-sglang-diffusion/prompts/executor.md
+++ b/sgl-engine-sglang-diffusion/prompts/executor.md
@@ -1,8 +1,11 @@
 # Executor runtime contract
 
-The assembled `goal.md` is the binding prompt. Read it in numbered precedence
-order. A lower-precedence knowledge excerpt cannot override the Sol-Engine
-correctness contract or the selected technique scope.
+The initial assembled `goal.md` and controller-owned `DELIVERY-CONTRACT.json`
+are binding. Read them in numbered precedence order. A lower-precedence
+knowledge excerpt cannot override the Sol-Engine correctness contract or the
+selected technique scope. On resume, the controller continues this same Codex
+thread with only the new findings; do not expect the complete goal to be
+replayed.
 
 Work only in the assigned detached SGLang worktree. Preserve the frozen
 baseline, workload, timing scope, real-run artifacts, source hashes, activation
@@ -40,6 +43,9 @@ The three skills complement one another and none replaces the full frozen
 workload run.
 Use metrics supported by the frozen GPU architecture: query the installed NCU
 metric set on Hopper rather than copying Blackwell-only metric names.
+Choose KernelWiki citations only from
+`DELIVERY-CONTRACT.json.pinned_kernelwiki_sources`; copy both its absolute
+reference path and exact digest. A run-local summary is not a pinned citation.
 
 For the `residency` lane, match every measured GPU UUID and total-memory value
 to the controller-owned `GPU-INVENTORY.json`, then begin with measured
@@ -56,18 +62,27 @@ and synchronization, distributed layout/collective implementation under the
 frozen topology, and repeated DiT kernels. Precision or approximate work stays
 in its quality-gated lane.
 
+Before a costly full workload, run a targeted correctness/microbenchmark screen
+and materialize the exact activation and production source diff. An existing
+flag may be used as a control, but an inert JSON/evidence file is not a patch
+for behavior activated by pre-existing flags.
+
 Do not treat process completion, a benchmark log, a claimed speedup, or the
 mere existence of output media as acceptance. Write the required
 `DELIVERY.json` only after its referenced durable artifacts exist. The
-deterministic verifier and master independently validate the delivery.
+deterministic verifier and master independently validate the delivery. Before
+exiting, run the exact `preflight_argv` from `DELIVERY-CONTRACT.json` and repair
+every static finding. Passing preflight does not replace the independent gate.
 
-If resumed, address the exact numbered master feedback without discarding the
-existing worktree or search ledger. Never weaken a gate to make a candidate
-pass.
+If resumed, address the exact numbered master feedback in the existing Codex
+thread without discarding the worktree or search ledger. Never weaken a gate to
+make a candidate pass.
 
 A rejected or slower hypothesis closes only that hypothesis. Continue through
 the technique's required coverage IDs until a measured candidate is delivered,
 the scientific-round budget is genuinely consumed, or `DISPOSITION.json`
 contains a complete evidence-backed coverage ledger. Process launches,
-dependency preflight, malformed output, and microbenchmarks are not scientific
-rounds.
+dependency preflight, pre-measurement malformed output, and microbenchmarks are
+not scientific rounds. A malformed evidence bundle that already contains an
+authenticated complete frozen-workload measurement does consume one round;
+repairing and resubmitting that same run never consumes it twice.

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py
@@ -84,9 +84,15 @@ def build_agent_argv(
     command: list[str] | tuple[str, ...],
     model: str | None,
     prompt: Path,
+    *,
+    resume_session_id: str | None = None,
 ) -> list[str]:
+    if resume_session_id is not None and not resume_session_id.strip():
+        raise ValueError("resume_session_id must not be empty")
     argv = [*command]
     if is_codex_exec(command):
+        if resume_session_id is not None:
+            argv.insert(2, "resume")
         if "--json" not in argv:
             argv.append("--json")
         if not any(
@@ -100,8 +106,35 @@ def build_agent_argv(
             argv.append("--dangerously-bypass-approvals-and-sandbox")
     if model:
         argv.extend(["--model", model])
+    if resume_session_id is not None:
+        if not is_codex_exec(command):
+            raise AgentRunnerError(
+                "session resumption is supported only for codex exec commands"
+            )
+        argv.append(resume_session_id)
     argv.append(str(prompt))
     return argv
+
+
+def read_codex_thread_id(stream: Path) -> str | None:
+    """Extract one durable Codex thread ID from a JSONL event stream."""
+    if not stream.is_file():
+        return None
+    thread_ids: set[str] = set()
+    for line in stream.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "thread.started":
+            continue
+        thread_id = event.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id.strip():
+            raise AgentRunnerError("Codex thread.started event has no thread_id")
+        thread_ids.add(thread_id)
+    if len(thread_ids) > 1:
+        raise AgentRunnerError("Codex JSONL stream contains conflicting thread IDs")
+    return next(iter(thread_ids), None)
 
 
 def _write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
@@ -127,8 +160,22 @@ class AgentRunner:
         self.model = model
         self._processes: dict[int, subprocess.Popen[bytes]] = {}
 
-    def argv(self, prompt: Path) -> list[str]:
-        return build_agent_argv(self.command, self.model, prompt)
+    @property
+    def supports_session_resume(self) -> bool:
+        return is_codex_exec(self.command)
+
+    def argv(
+        self,
+        prompt: Path,
+        *,
+        resume_session_id: str | None = None,
+    ) -> list[str]:
+        return build_agent_argv(
+            self.command,
+            self.model,
+            prompt,
+            resume_session_id=resume_session_id,
+        )
 
     def launch(
         self,
@@ -140,6 +187,7 @@ class AgentRunner:
         stderr: Path | None = None,
         env: Mapping[str, str] | None = None,
         context: Mapping[str, object] | None = None,
+        resume_session_id: str | None = None,
     ) -> AgentProcess:
         prompt = prompt.resolve()
         cwd = cwd.resolve()
@@ -155,7 +203,7 @@ class AgentRunner:
         stderr = (stderr or receipt.with_suffix(".stderr.log")).resolve()
         stdout.parent.mkdir(parents=True, exist_ok=True)
         stderr.parent.mkdir(parents=True, exist_ok=True)
-        argv = self.argv(prompt)
+        argv = self.argv(prompt, resume_session_id=resume_session_id)
         merged_environment = os.environ.copy()
         environment_overrides = dict(env or {})
         merged_environment.update(environment_overrides)
@@ -188,6 +236,10 @@ class AgentRunner:
                     "stdout": str(stdout),
                     "stderr": str(stderr),
                     "start_new_session": True,
+                    "agent_session_mode": (
+                        "resume" if resume_session_id is not None else "new"
+                    ),
+                    "resumed_thread_id": resume_session_id,
                     "context": dict(context or {}),
                 },
             )

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/agents.py
@@ -86,8 +86,18 @@ def build_agent_argv(
     prompt: Path,
 ) -> list[str]:
     argv = [*command]
-    if is_codex_exec(command) and "--json" not in argv:
-        argv.append("--json")
+    if is_codex_exec(command):
+        if "--json" not in argv:
+            argv.append("--json")
+        if not any(
+            item in {"--dangerously-bypass-approvals-and-sandbox", "--sandbox", "-s"}
+            or item.startswith("--sandbox=")
+            for item in argv
+        ):
+            # Executor worktrees live inside an already isolated campaign
+            # container. Non-interactive Codex otherwise defaults to a
+            # read-only sandbox and cannot produce the required delivery.
+            argv.append("--dangerously-bypass-approvals-and-sandbox")
     if model:
         argv.extend(["--model", model])
     argv.append(str(prompt))

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/cli.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/cli.py
@@ -144,6 +144,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=PACKAGE_ROOT / "contracts/sol_engine/source-hashes.json",
     )
+    preflight = subparsers.add_parser("preflight-delivery")
+    preflight.add_argument("--campaign", type=Path, required=True)
+    preflight.add_argument("--technique", required=True)
+    preflight.add_argument("--executor-worktree", type=Path, required=True)
+    preflight.add_argument("--delivery", type=Path, required=True)
     return parser
 
 
@@ -231,6 +236,54 @@ def main(argv: list[str] | None = None) -> int:
         for issue in issues:
             print(issue, file=sys.stderr)
         return 1 if issues else 0
+    if args.command == "preflight-delivery":
+        from .baseline import BaselineRunner
+        from .request import FrozenBenchmarkCommand
+        from .techniques import TechniqueRegistry
+        from .verifier import DeliveryVerifier
+
+        class StaticAuditor:
+            def audit(self, **_: Any) -> bool:
+                raise AssertionError("static preflight invoked an independent auditor")
+
+        campaign = args.campaign.resolve()
+        registry = TechniqueRegistry.load(PACKAGE_ROOT / "techniques/registry.toml")
+        if args.technique not in registry.names():
+            raise ValueError(f"unknown technique: {args.technique}")
+        template_path = campaign / "BASELINE-COMMAND.json"
+        template = (
+            FrozenBenchmarkCommand.model_validate_json(template_path.read_text())
+            if template_path.is_file()
+            else None
+        )
+        result = DeliveryVerifier(
+            registry=registry,
+            baseline=BaselineRunner.load(campaign / "BASELINE.json"),
+            campaign_artifact_root=campaign,
+            method_auditor=StaticAuditor(),
+            quality_evaluator=None,
+            command_template=template,
+        ).verify(
+            args.delivery.resolve(),
+            technique=args.technique,
+            executor_worktree=args.executor_worktree.resolve(),
+            independent_gates=False,
+        )
+        payload = {
+            "accepted": result.accepted,
+            "technique": result.technique,
+            "independent_gates_run": False,
+            "findings": [
+                {
+                    "code": finding.code,
+                    "message": finding.message,
+                    "candidate_id": finding.candidate_id,
+                }
+                for finding in result.findings
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if result.accepted else 1
     if args.command in {"run", "resume", "package"}:
         # The default runtime is imported lazily so status/init remain CPU-only.
         from .runtime import run_campaign_command

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/delivery_contract.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/delivery_contract.py
@@ -1,0 +1,179 @@
+"""Controller-owned, machine-readable Executor delivery contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .knowledge import KnowledgeSyncError, snapshot_reference_files
+from .models import (
+    BaselineRecord,
+    CandidateManifest,
+    Delivery,
+    EngagementReceipt,
+    KernelEvidence,
+    ResidencyEvidence,
+)
+from .request import FrozenBenchmarkCommand
+from .techniques import TechniqueRegistry
+
+
+WORKTREE_PLACEHOLDER = "{{executor_worktree}}"
+DELIVERY_PLACEHOLDER = "{{delivery_path}}"
+
+
+class DeliveryContractError(RuntimeError):
+    """The controller cannot produce a complete delivery contract."""
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _artifact_binding(path: Path) -> dict[str, str] | None:
+    return {"path": str(path), "sha256": _sha256(path)} if path.is_file() else None
+
+
+def _kernelwiki_sources(campaign: Path) -> list[dict[str, str]]:
+    try:
+        manifest = json.loads((campaign / "KNOWLEDGE.json").read_text())
+        index = Path(manifest["snapshots"]["kda_pilot"])
+        references = snapshot_reference_files(
+            index,
+            prefix="external/KernelWiki",
+        )
+    except (OSError, KeyError, TypeError, json.JSONDecodeError, KnowledgeSyncError) as error:
+        raise DeliveryContractError(
+            f"cannot build contract without pinned KernelWiki references: {error}"
+        ) from error
+    return [
+        {"path": str(path), "sha256": digest}
+        for path, digest in sorted(references.items(), key=lambda item: str(item[0]))
+    ]
+
+
+def build_delivery_contract(
+    *,
+    campaign: Path,
+    technique: str,
+    registry: TechniqueRegistry,
+    baseline: BaselineRecord,
+    command_template: FrozenBenchmarkCommand | None,
+) -> dict[str, Any]:
+    """Build the exact static contract consumed by one Executor lane."""
+    campaign = campaign.resolve()
+    contract = registry[technique]
+    profile = campaign / "profiles/0/PROFILE-DIGEST.json"
+    if not profile.is_file():
+        raise DeliveryContractError("active profile digest is missing")
+    required = [
+        "PERFORMANCE.json",
+        "outputs/benchmark.jsonl",
+        "outputs/media/",
+        "implementation-manifest.json",
+        "source-hashes.json",
+        "engagement-receipt.json",
+    ]
+    if command_template is not None:
+        required.append("COMMAND.json")
+    if contract.correctness == "lossless":
+        required.extend(["equivalence.json", "authenticity.json"])
+    if technique == "kernel":
+        required.append("KERNEL-EVIDENCE.json")
+    elif technique == "residency":
+        required.append("RESIDENCY-EVIDENCE.json")
+
+    technique_schema: dict[str, Any] | None = None
+    pinned_kernelwiki: list[dict[str, str]] = []
+    if technique == "kernel":
+        technique_schema = KernelEvidence.model_json_schema()
+        pinned_kernelwiki = _kernelwiki_sources(campaign)
+    elif technique == "residency":
+        technique_schema = ResidencyEvidence.model_json_schema()
+
+    command_path = campaign / "BASELINE-COMMAND.json"
+    inventory_path = campaign / "GPU-INVENTORY.json"
+    unavailable_inventory_path = campaign / "GPU-INVENTORY-UNAVAILABLE.json"
+
+    return {
+        "schema_version": 1,
+        "technique": technique,
+        "correctness": contract.correctness,
+        "executor_worktree": WORKTREE_PLACEHOLDER,
+        "delivery_path": DELIVERY_PLACEHOLDER,
+        "baseline": {
+            "path": str(campaign / "BASELINE.json"),
+            "sha256": _sha256(campaign / "BASELINE.json"),
+            "model_id": baseline.model_id,
+            "sglang_commit": baseline.sglang_commit,
+            "timing_scope": baseline.timing_scope,
+            "mean_e2e_s": baseline.mean_e2e_s,
+            "workload_total_s": baseline.workload_total_s,
+            "request_count": baseline.request_count,
+        },
+        "profile": {"path": str(profile), "sha256": _sha256(profile)},
+        "command_template": _artifact_binding(command_path),
+        "command_template_sha256": (
+            command_template.template_sha256 if command_template is not None else None
+        ),
+        "gpu_inventory": _artifact_binding(inventory_path),
+        "gpu_inventory_unavailable": _artifact_binding(unavailable_inventory_path),
+        "required_artifacts": required,
+        "performance_artifact_required_fields": {
+            "schema_version": 2,
+            "mean_e2e_s": "positive number",
+            "workload_total_s": "mean_e2e_s * request_count",
+            "request_count": 5,
+            "peak_memory_mib": "positive number",
+            "timing_scope": baseline.timing_scope,
+        },
+        "schemas": {
+            "delivery": Delivery.model_json_schema(),
+            "candidate_manifest": CandidateManifest.model_json_schema(),
+            "engagement_receipt": EngagementReceipt.model_json_schema(),
+            "technique_evidence": technique_schema,
+        },
+        "pinned_kernelwiki_sources": pinned_kernelwiki,
+        "preflight_argv": [
+            sys.executable,
+            "-m",
+            "sgl_engine_sglang_diffusion.cli",
+            "preflight-delivery",
+            "--campaign",
+            str(campaign),
+            "--technique",
+            technique,
+            "--executor-worktree",
+            WORKTREE_PLACEHOLDER,
+            "--delivery",
+            DELIVERY_PLACEHOLDER,
+        ],
+    }
+
+
+def materialize_delivery_contract(
+    value: Mapping[str, Any],
+    *,
+    worktree: Path,
+    delivery: Path,
+) -> dict[str, Any]:
+    """Replace controller placeholders without interpreting arbitrary strings."""
+    replacements = {
+        WORKTREE_PLACEHOLDER: str(worktree.resolve()),
+        DELIVERY_PLACEHOLDER: str(delivery.resolve()),
+    }
+
+    def visit(item: Any) -> Any:
+        if isinstance(item, str):
+            return replacements.get(item, item)
+        if isinstance(item, Mapping):
+            return {str(key): visit(child) for key, child in item.items()}
+        if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+            return [visit(child) for child in item]
+        return item
+
+    return visit(dict(value))

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/integrator.py
@@ -311,6 +311,10 @@ class IntegrationManager:
             result = run(
                 ["git", "cherry-pick", candidate_commit],
                 cwd=worktree,
+                env={
+                    "GIT_COMMITTER_NAME": "SGL Diffusion Engine",
+                    "GIT_COMMITTER_EMAIL": "sgl-diffusion-engine@localhost",
+                },
                 check=False,
             )
             if result.returncode == 0:

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/knowledge.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/knowledge.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
+import tempfile
 import tomllib
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -185,18 +187,95 @@ def _iter_allowed_files(checkout: Path, patterns: Iterable[str]) -> list[Path]:
     return sorted(matched, key=lambda path: path.relative_to(root).as_posix())
 
 
+def _read_snapshot(index_path: Path) -> KnowledgeSnapshot:
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise KnowledgeSyncError("knowledge index must contain an object")
+        return KnowledgeSnapshot.from_dict(data)
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        raise KnowledgeSyncError(
+            f"knowledge index is invalid: {index_path}: {error}"
+        ) from error
+
+
 def _load_existing_snapshot(
     index_path: Path, *, source: str, commit: str
 ) -> KnowledgeSnapshot | None:
     if not index_path.is_file():
         return None
-    data = json.loads(index_path.read_text(encoding="utf-8"))
-    snapshot = KnowledgeSnapshot.from_dict(data)
+    snapshot = _read_snapshot(index_path)
     if snapshot.source != source or snapshot.commit != commit:
         raise KnowledgeSyncError(
             "knowledge output already belongs to a different source revision"
         )
     return snapshot
+
+
+def _validate_snapshot(
+    output_dir: Path,
+    snapshot: KnowledgeSnapshot,
+    *,
+    required_prefixes: Iterable[str],
+) -> None:
+    if not snapshot.entries:
+        raise KnowledgeSyncError("knowledge snapshot contains no allowlisted files")
+    entry_paths = [entry.path for entry in snapshot.entries]
+    for raw_prefix in required_prefixes:
+        prefix = Path(raw_prefix)
+        if prefix.is_absolute() or ".." in prefix.parts:
+            raise KnowledgeSyncError(
+                f"unsafe required knowledge prefix: {raw_prefix}"
+            )
+        normalized = prefix.as_posix().rstrip("/") + "/"
+        if not any(path.startswith(normalized) for path in entry_paths):
+            raise KnowledgeSyncError(
+                f"required knowledge prefix has no entries: {normalized}"
+            )
+    references = (output_dir / "references").resolve()
+    for entry in snapshot.entries:
+        reference = (references / entry.path).resolve()
+        try:
+            reference.relative_to(references)
+        except ValueError as exc:
+            raise KnowledgeSyncError(
+                f"knowledge reference escapes snapshot: {entry.path}"
+            ) from exc
+        if not reference.is_file() or reference.is_symlink():
+            raise KnowledgeSyncError(
+                f"knowledge reference is missing or unsafe: {entry.path}"
+            )
+        actual = hashlib.sha256(reference.read_bytes()).hexdigest()
+        if actual != entry.reference_sha256:
+            raise KnowledgeSyncError(
+                f"knowledge reference digest mismatch: {entry.path}"
+            )
+
+
+def snapshot_reference_files(
+    index_path: Path,
+    *,
+    prefix: str | None = None,
+) -> dict[Path, str]:
+    """Return validated copied references and their immutable digests."""
+    index_path = index_path.resolve()
+    if not index_path.is_file():
+        raise KnowledgeSyncError(f"knowledge index is missing: {index_path}")
+    snapshot = _read_snapshot(index_path)
+    _validate_snapshot(index_path.parent, snapshot, required_prefixes=())
+    normalized = prefix.rstrip("/") + "/" if prefix is not None else None
+    result = {
+        (index_path.parent / "references" / entry.path).resolve(): (
+            entry.reference_sha256
+        )
+        for entry in snapshot.entries
+        if normalized is None or entry.path.startswith(normalized)
+    }
+    if normalized is not None and not result:
+        raise KnowledgeSyncError(
+            f"required knowledge prefix has no entries: {normalized}"
+        )
+    return result
 
 
 def sync_source(
@@ -206,6 +285,7 @@ def sync_source(
     commit: str,
     patterns: Iterable[str],
     output_dir: Path,
+    required_prefixes: Iterable[str] = (),
 ) -> KnowledgeSnapshot:
     """Create an immutable text-only knowledge snapshot for one locked source."""
     if not re.fullmatch(r"[0-9a-f]{40}", commit):
@@ -217,52 +297,77 @@ def sync_source(
     index_path = output_dir / "index.json"
     existing = _load_existing_snapshot(index_path, source=name, commit=commit)
     if existing is not None:
+        _validate_snapshot(
+            output_dir,
+            existing,
+            required_prefixes=required_prefixes,
+        )
         return existing
     if output_dir.exists() and any(output_dir.iterdir()):
         raise KnowledgeSyncError(
             f"knowledge output is nonempty without a valid index: {output_dir}"
         )
 
-    references_dir = output_dir / "references"
+    source_paths = _iter_allowed_files(checkout, patterns)
+    if not source_paths:
+        raise KnowledgeSyncError("knowledge source matched no allowlisted files")
+
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{output_dir.name}.staging-", dir=output_dir.parent)
+    )
+    references_dir = staging / "references"
     references_dir.mkdir(parents=True, exist_ok=True)
     entries: list[KnowledgeEntry] = []
-    for source_path in _iter_allowed_files(checkout, patterns):
-        raw = source_path.read_bytes()
-        if len(raw) > MAX_KNOWLEDGE_FILE_BYTES:
-            raise KnowledgeSyncError(
-                f"knowledge file exceeds {MAX_KNOWLEDGE_FILE_BYTES} bytes: "
-                f"{source_path.relative_to(checkout)}"
+    try:
+        for source_path in source_paths:
+            raw = source_path.read_bytes()
+            if len(raw) > MAX_KNOWLEDGE_FILE_BYTES:
+                raise KnowledgeSyncError(
+                    f"knowledge file exceeds {MAX_KNOWLEDGE_FILE_BYTES} bytes: "
+                    f"{source_path.relative_to(checkout)}"
+                )
+            relative = source_path.relative_to(checkout)
+            text = sanitize_text(raw.decode("utf-8", errors="replace"))
+            reference = references_dir / relative
+            reference.parent.mkdir(parents=True, exist_ok=True)
+            reference.write_text(text, encoding="utf-8")
+            headings, symbols = _extract_metadata(text)
+            entries.append(
+                KnowledgeEntry(
+                    path=relative.as_posix(),
+                    media_type=_media_type(source_path),
+                    sha256=hashlib.sha256(raw).hexdigest(),
+                    reference_sha256=hashlib.sha256(text.encode()).hexdigest(),
+                    headings=headings,
+                    symbols=symbols,
+                )
             )
-        relative = source_path.relative_to(checkout)
-        text = sanitize_text(raw.decode("utf-8", errors="replace"))
-        reference = references_dir / relative
-        reference.parent.mkdir(parents=True, exist_ok=True)
-        reference.write_text(text, encoding="utf-8")
-        headings, symbols = _extract_metadata(text)
-        entries.append(
-            KnowledgeEntry(
-                path=relative.as_posix(),
-                media_type=_media_type(source_path),
-                sha256=hashlib.sha256(raw).hexdigest(),
-                reference_sha256=hashlib.sha256(text.encode()).hexdigest(),
-                headings=headings,
-                symbols=symbols,
-            )
-        )
 
-    snapshot = KnowledgeSnapshot(
-        schema_version=1,
-        source=name,
-        commit=commit,
-        entries=tuple(entries),
-    )
-    temporary_index = output_dir / ".index.json.tmp"
-    temporary_index.write_text(
-        json.dumps(snapshot.to_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    temporary_index.replace(index_path)
-    return snapshot
+        snapshot = KnowledgeSnapshot(
+            schema_version=1,
+            source=name,
+            commit=commit,
+            entries=tuple(entries),
+        )
+        temporary_index = staging / ".index.json.tmp"
+        temporary_index.write_text(
+            json.dumps(snapshot.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_index.replace(staging / "index.json")
+        _validate_snapshot(
+            staging,
+            snapshot,
+            required_prefixes=required_prefixes,
+        )
+        if output_dir.exists():
+            output_dir.rmdir()
+        staging.replace(output_dir)
+        return snapshot
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
 
 
 def compute_contract_hashes(

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py
@@ -13,7 +13,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-from .agents import AgentRunner
+from .agents import AgentRunner, read_codex_thread_id
+from .delivery_contract import materialize_delivery_contract
 from .models import SourceLock
 from .sources import SourceManager
 from .state import IdempotencyConflict, StateStore
@@ -54,6 +55,7 @@ class ExecutorPrompt:
     baseline: PromptSection
     search_state: Mapping[str, Any]
     rejected_signatures: tuple[str, ...] = ()
+    delivery_contract: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -70,6 +72,7 @@ class ExecutorHandle:
     attempt: int
     lease_resource: str
     lease_owner: str
+    session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -112,6 +115,7 @@ def assemble_executor_prompt(
     *,
     worktree: Path,
     delivery: Path,
+    contract_path: Path | None = None,
 ) -> str:
     """Assemble a provenance-addressed prompt in contract precedence order."""
     worktree = worktree.resolve()
@@ -151,11 +155,31 @@ def assemble_executor_prompt(
                 ),
             )
         )
+    sections.append(("5", inputs.baseline))
+    next_index = 6
+    if inputs.delivery_contract is not None:
+        if contract_path is None:
+            raise ValueError("delivery contract path is required")
+        sections.append(
+            (
+                str(next_index),
+                PromptSection(
+                    name="Controller delivery contract and static preflight",
+                    content=_canonical_json(dict(inputs.delivery_contract)),
+                    source=str(contract_path.resolve()),
+                ),
+            )
+        )
+        next_index += 1
+        destination_content += (
+            f"Controller contract: {contract_path.resolve()}\n"
+            "Run its preflight_argv and repair every finding before exiting. "
+            "Static preflight is required but is not independent approval.\n"
+        )
     sections.extend(
         [
-            ("5", inputs.baseline),
             (
-                "6",
+                str(next_index),
                 PromptSection(
                     name="Current search state and rejected signatures",
                     content=search_content,
@@ -163,7 +187,7 @@ def assemble_executor_prompt(
                 ),
             ),
             (
-                "7",
+                str(next_index + 1),
                 PromptSection(
                     name="Assigned worktree and delivery contract",
                     content=destination_content,
@@ -284,8 +308,35 @@ class ExecutorManager:
         executor_root = self.root / "executors" / executor_id
         worktree = executor_root / "worktree"
         delivery = worktree / "DELIVERY.json"
+        contract_path = executor_root / "DELIVERY-CONTRACT.json"
+        materialized_contract = (
+            materialize_delivery_contract(
+                prompt.delivery_contract,
+                worktree=worktree,
+                delivery=delivery,
+            )
+            if prompt.delivery_contract is not None
+            else None
+        )
+        effective_prompt = (
+            ExecutorPrompt(
+                correctness_contract=prompt.correctness_contract,
+                technique_scope=prompt.technique_scope,
+                placement_rules=prompt.placement_rules,
+                knowledge=prompt.knowledge,
+                baseline=prompt.baseline,
+                search_state=prompt.search_state,
+                rejected_signatures=prompt.rejected_signatures,
+                delivery_contract=materialized_contract,
+            )
+            if materialized_contract is not None
+            else prompt
+        )
         prompt_text = assemble_executor_prompt(
-            prompt, worktree=worktree, delivery=delivery
+            effective_prompt,
+            worktree=worktree,
+            delivery=delivery,
+            contract_path=(contract_path if materialized_contract is not None else None),
         )
         event_payload = {
             "executor_id": executor_id,
@@ -333,6 +384,15 @@ class ExecutorManager:
                 return handle
 
             executor_root.mkdir(parents=True, exist_ok=True)
+            if materialized_contract is not None:
+                contract_text = _canonical_json(materialized_contract)
+                if contract_path.is_file():
+                    if contract_path.read_text(encoding="utf-8") != contract_text:
+                        raise IdempotencyConflict(
+                            "delivery contract changed for an existing executor"
+                        )
+                else:
+                    _write_text_atomic(contract_path, contract_text)
             if not worktree.exists():
                 self.sources.create_worktree(source_lock, worktree)
             elif not (worktree / ".git").exists():
@@ -373,6 +433,8 @@ class ExecutorManager:
             delivery = require_regular_delivery(handle.worktree, handle.delivery)
             delivered = True
         if not status.alive:
+            if self.runner.supports_session_resume:
+                self._session_id(handle, required=False)
             self.state.release_lease(handle.lease_resource, handle.lease_owner)
         return ExecutorPoll(
             executor_id=handle.executor_id,
@@ -476,8 +538,13 @@ class ExecutorManager:
         else:
             _write_text_atomic(feedback_path, feedback)
 
-        base_prompt = (handle.root / "goal.base.md").read_text(encoding="utf-8")
-        prompt_text = self._prompt_with_feedback(base_prompt, handle.root)
+        resume_session_id: str | None = None
+        if self.runner.supports_session_resume:
+            resume_session_id = self._session_id(handle, required=True)
+            prompt_text = self._compact_feedback_prompt(handle, feedback)
+        else:
+            base_prompt = (handle.root / "goal.base.md").read_text(encoding="utf-8")
+            prompt_text = self._prompt_with_feedback(base_prompt, handle.root)
         _write_text_atomic(handle.prompt, prompt_text)
 
         # The receipt is the launch boundary. If it exists, recover the
@@ -495,6 +562,7 @@ class ExecutorManager:
                 attempt=attempt,
                 lease_resource=handle.lease_resource,
                 lease_owner=handle.lease_owner,
+                resume_session_id=resume_session_id,
             )
 
         if handle.delivery.exists() or handle.delivery.is_symlink():
@@ -517,6 +585,7 @@ class ExecutorManager:
             attempt=attempt,
             lease_resource=handle.lease_resource,
             lease_owner=handle.lease_owner,
+            resume_session_id=resume_session_id,
         )
 
     def close(self) -> None:
@@ -535,6 +604,7 @@ class ExecutorManager:
         attempt: int,
         lease_resource: str,
         lease_owner: str,
+        resume_session_id: str | None = None,
     ) -> ExecutorHandle:
         receipt = executor_root / f"process-{attempt:03d}.json"
         if receipt.exists() or receipt.is_symlink():
@@ -545,6 +615,7 @@ class ExecutorManager:
             if (
                 process_receipt.get("schema_version") != 1
                 or process_receipt.get("start_new_session") is not True
+                or process_receipt.get("resumed_thread_id") != resume_session_id
                 or Path(process_receipt["cwd"]).resolve() != worktree.resolve()
                 or Path(process_receipt["prompt"]).resolve() != prompt.resolve()
                 or process_receipt["prompt_sha256"] != expected_prompt_hash
@@ -563,6 +634,7 @@ class ExecutorManager:
                 stdout=executor_root / f"stdout-{attempt:03d}.log",
                 stderr=executor_root / f"stderr-{attempt:03d}.log",
                 env=self.agent_environment,
+                resume_session_id=resume_session_id,
                 context={
                     "campaign_id": campaign_id,
                     "agent_role": "executor",
@@ -585,6 +657,7 @@ class ExecutorManager:
             attempt=attempt,
             lease_resource=lease_resource,
             lease_owner=lease_owner,
+            session_id=resume_session_id,
         )
         payload = self._handle_payload(handle)
         _write_json_atomic(executor_root / f"attempt-{attempt:03d}.json", payload)
@@ -618,6 +691,11 @@ class ExecutorManager:
             attempt=int(payload["attempt"]),
             lease_resource=str(payload["lease_resource"]),
             lease_owner=str(payload["lease_owner"]),
+            session_id=(
+                str(payload["session_id"])
+                if payload.get("session_id") is not None
+                else None
+            ),
         )
         if handle.root.resolve() != executor_root.resolve():
             raise OrchestrationError(f"executor manifest root mismatch: {handle.root}")
@@ -668,6 +746,70 @@ class ExecutorManager:
                 f"{feedback}\n"
             )
         return result
+
+    @staticmethod
+    def _compact_feedback_prompt(handle: ExecutorHandle, feedback: str) -> str:
+        contract = handle.root / "DELIVERY-CONTRACT.json"
+        lines = [
+            "# Continue the existing optimization executor turn",
+            "",
+            "Repair the existing candidate and delivery in the assigned worktree.",
+            f"Required delivery path: {handle.delivery}",
+        ]
+        if contract.is_file():
+            lines.append(f"Controller delivery contract: {contract}")
+            payload = json.loads(contract.read_text(encoding="utf-8"))
+            preflight = payload.get("preflight_argv")
+            if isinstance(preflight, list) and all(
+                isinstance(item, str) for item in preflight
+            ):
+                lines.extend(
+                    [
+                        "Static preflight argv (execute directly, without a shell):",
+                        json.dumps(preflight),
+                    ]
+                )
+        lines.extend(["", "## New verifier findings", "", feedback.strip(), ""])
+        return "\n".join(lines)
+
+    def _session_id(
+        self,
+        handle: ExecutorHandle,
+        *,
+        required: bool,
+    ) -> str | None:
+        session_path = handle.root / "SESSION.json"
+        if session_path.is_file() and not session_path.is_symlink():
+            payload = json.loads(session_path.read_text(encoding="utf-8"))
+            thread_id = payload.get("thread_id")
+            if isinstance(thread_id, str) and thread_id:
+                return thread_id
+            raise OrchestrationError(f"invalid executor session manifest: {session_path}")
+
+        observed: set[str] = set()
+        for stream in sorted(handle.root.glob("stdout-*.log")):
+            thread_id = read_codex_thread_id(stream)
+            if thread_id is not None:
+                observed.add(thread_id)
+        if len(observed) > 1:
+            raise OrchestrationError("executor attempts contain conflicting Codex threads")
+        if observed:
+            thread_id = next(iter(observed))
+            _write_json_atomic(
+                session_path,
+                {
+                    "schema_version": 1,
+                    "executor_id": handle.executor_id,
+                    "thread_id": thread_id,
+                },
+            )
+            return thread_id
+        if required:
+            raise OrchestrationError(
+                "Codex executor produced no thread.started event; refusing to start "
+                "a fresh conversation during resume"
+            )
+        return None
 
     def _event_by_key(
         self, campaign_id: str, idempotency_key: str

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/orchestration.py
@@ -246,6 +246,22 @@ class ExecutorManager:
         self.runner = runner
         self.lease_ttl_seconds = lease_ttl_seconds
         self.agent_environment = dict(agent_environment or {})
+        # Executors work in detached worktrees and are expected to commit their
+        # candidate before delivery.  Minimal containers often have no global
+        # Git identity, so provide a deterministic process-local identity
+        # without mutating either the user's global config or the source repo.
+        self.agent_environment.setdefault(
+            "GIT_AUTHOR_NAME", "sgl-diffusion-engine executor"
+        )
+        self.agent_environment.setdefault(
+            "GIT_AUTHOR_EMAIL", "sgl-diffusion-engine@localhost"
+        )
+        self.agent_environment.setdefault(
+            "GIT_COMMITTER_NAME", "sgl-diffusion-engine executor"
+        )
+        self.agent_environment.setdefault(
+            "GIT_COMMITTER_EMAIL", "sgl-diffusion-engine@localhost"
+        )
         self._lock = threading.RLock()
 
     def spawn(

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/profiler.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/profiler.py
@@ -320,6 +320,7 @@ class TechniqueRouter:
 
     def __init__(self) -> None:
         self.last_evidence: dict[str, dict[str, Any]] = {}
+        self.route_policy = "lossless-first-v1"
 
     def route(
         self,
@@ -327,9 +328,11 @@ class TechniqueRouter:
         *,
         allow_quality_gated: bool,
         gpu_count: int,
+        target_speedup: float = 2.0,
     ) -> list[str]:
         if gpu_count < 1:
             raise ValueError("gpu_count must be positive")
+        self.route_policy = "lossless-first-v1"
         Profiler.validate_digest(digest)
         hotspots = [
             {
@@ -356,8 +359,14 @@ class TechniqueRouter:
         # Multi-GPU profiles still feed collective/layout candidates to kernel.
         routes = ["residency", "kernel"]
         if allow_quality_gated:
-            for technique in ("cache", "pisa", "quantization", "token_pruning"):
-                routes.append(technique)
+            quality_lanes = ("cache", "pisa", "quantization", "token_pruning")
+            if target_speedup >= 3.0:
+                self.route_policy = "large-gap-quality-first-v1"
+                routes = ["residency", *quality_lanes, "kernel"]
+            else:
+                self.route_policy = "lossless-first-v1"
+                routes.extend(quality_lanes)
+            for technique in quality_lanes:
                 self.last_evidence[technique] = {
                     "hotspots": hotspots,
                     "knowledge": [

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/progress.py
@@ -34,6 +34,13 @@ def build_progress(campaign: Path) -> dict[str, Any]:
     attempts = _technique_attempts(events)
     scientific_rounds = _scientific_rounds(events)
     isolated = _isolated_speedups(campaign)
+    active_technique = _active_technique(campaign, epoch)
+    dispositions = _technique_names(
+        campaign / "TECHNIQUE-DISPOSITIONS.json", "techniques"
+    )
+    deferred = _technique_names(
+        campaign / "search" / str(epoch) / "DEFERRED-LANES.json", "lanes"
+    )
     (
         integrated_speedup,
         integrated_mean_e2e_s,
@@ -55,8 +62,17 @@ def build_progress(campaign: Path) -> dict[str, Any]:
             state = "integrated"
         elif technique in isolated:
             state = "verified"
+        elif technique in dispositions:
+            state = "dispositioned"
+        elif technique in deferred:
+            state = "deferred"
+        elif (
+            status is CampaignStatus.SEARCHING
+            and technique == active_technique
+        ):
+            state = "running"
         elif attempts.get(technique, 0) > 0:
-            state = "running" if status is CampaignStatus.SEARCHING else "attempted"
+            state = "attempted"
         else:
             state = "pending"
         rows.append(
@@ -288,6 +304,20 @@ def _routes(campaign: Path, defaults: list[str]) -> list[str]:
     if value is None or not isinstance(value.get("routes"), list):
         return list(defaults)
     return [str(item) for item in value["routes"]]
+
+
+def _active_technique(campaign: Path, epoch: int) -> str | None:
+    value = _read_object_optional(
+        campaign / "search" / str(epoch) / "EXECUTORS.json"
+    )
+    active = value.get("active_technique") if value is not None else None
+    return active if isinstance(active, str) and active else None
+
+
+def _technique_names(path: Path, field: str) -> set[str]:
+    value = _read_object_optional(path)
+    raw = value.get(field) if value is not None else None
+    return {str(name) for name in raw} if isinstance(raw, dict) else set()
 
 
 def _token_breakdown(records: list[dict[str, Any]], field: str) -> dict[str, int]:

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/request.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/request.py
@@ -42,6 +42,9 @@ _PLACEHOLDERS = {
     "prompts": "{{prompts}}",
 }
 _VALUE_FLAGS = {
+    "--backend",
+    "--batch-size",
+    "--performance-mode",
     "--model-path",
     "--dataset",
     "--dataset-path",
@@ -70,9 +73,16 @@ _VALUE_FLAGS = {
     "--dp-size",
     "--dp",
     "--gpu-ids",
+    "--num-gpus",
+    "--minimax-h3-task",
+    "--minimax-h3-conditions-json",
+    "--minimax-h3-target-json",
+    "--flow-shift",
+    "--audio-flow-shift",
 }
 _PARALLEL_FLAGS = frozenset(
     {
+        "--num-gpus",
         "--tensor-parallel-size",
         "--pipeline-parallel-size",
         "--context-parallel-size",
@@ -91,6 +101,9 @@ _PARALLEL_FLAGS = frozenset(
 )
 _PARALLEL_SWITCH_FLAGS = frozenset({"--enable-cfg-parallel"})
 _FROZEN_FLAGS = {
+    "--backend",
+    "--batch-size",
+    "--performance-mode",
     "--model-path",
     "--dataset",
     "--dataset-path",
@@ -103,7 +116,20 @@ _FROZEN_FLAGS = {
     "--num-inference-steps",
     "--guidance-scale",
     "--dtype",
+    "--minimax-h3-task",
+    "--minimax-h3-conditions-json",
+    "--minimax-h3-target-json",
+    "--flow-shift",
+    "--audio-flow-shift",
 }
+_FROZEN_SWITCH_FLAGS = frozenset(
+    {
+        "--disable-safety-checker",
+        "--profile",
+        "--profile-all-stages",
+        "--skip-warmup",
+    }
+)
 
 
 class BaselineCommandRequest(StrictModel):
@@ -204,6 +230,16 @@ class FrozenBenchmarkCommand(StrictModel):
                 + ", ".join(conflicts)
             )
         environment.update(requested_environment)
+        changed_switches = sorted(
+            flag
+            for flag in _FROZEN_SWITCH_FLAGS
+            if _flag_count(activation_args, flag)
+        )
+        if changed_switches:
+            raise RequestError(
+                "candidate activation changes frozen workload switches: "
+                + ", ".join(changed_switches)
+            )
         if profile:
             if "--profile" not in argv:
                 argv.extend(["--profile", "--num-profiled-timesteps", "5"])
@@ -283,9 +319,9 @@ def normalize_launch_request(
     if "--num-prompts" not in flags:
         raise RequestError("baseline command is missing --num-prompts 5")
     prompt_count = int(flags["--num-prompts"])
-    if prompt_count != 5 or len(prompts) < 5:
+    if prompt_count != 5 or len(prompts) != 5:
         raise RequestError(
-            "Sol-compatible campaigns require --num-prompts 5 and at least "
+            "Sol-compatible campaigns require --num-prompts 5 and exactly "
             "five non-empty prompts"
         )
 
@@ -305,6 +341,9 @@ def normalize_launch_request(
     workload_values = {
         name: str(flags.get(name, default))
         for name, default in {
+            "--backend": "sglang",
+            "--batch-size": "1",
+            "--performance-mode": "<absent>",
             "--seed": "42",
             "--width": "32",
             "--height": "32",
@@ -322,6 +361,19 @@ def normalize_launch_request(
         "--num-prompts": "5",
         **workload_values,
     }
+    frozen_flags.update(
+        {
+            name: flags[name]
+            for name in _FROZEN_FLAGS
+            if name in flags and name not in frozen_flags
+        }
+    )
+    frozen_flags.update(
+        {
+            "--output-file": _PLACEHOLDERS["output_file"],
+            "--output-path": _PLACEHOLDERS["media_dir"],
+        }
+    )
     parallel_flags = _parallel_projection(template)
     frozen_flags.update(parallel_flags)
     digest_payload = {

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/runtime.py
@@ -17,6 +17,7 @@ from .agents import AgentRunner, build_agent_argv, redact_argv
 from .baseline import BaselineRunner
 from .config import load_goal
 from .controller import CampaignController, StepResult
+from .delivery_contract import build_delivery_contract
 from .driver import SGLangDiffusionDriver
 from .integrator import (
     CandidateActivation,
@@ -27,7 +28,7 @@ from .integrator import (
     VerifiedCandidate,
 )
 from .history_rules import HistoryRuleCatalog
-from .knowledge import check_contract_hashes
+from .knowledge import KnowledgeSyncError, check_contract_hashes
 from .knowledge import load_registry as load_knowledge_registry
 from .knowledge import read_source_lock, sync_source
 from .models import (
@@ -67,6 +68,14 @@ class CampaignRuntimeError(RuntimeError):
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 _SOURCE_NAMES = ("sglang", "sol_engine", "fastvideo", "kda_pilot")
+_KDA_REQUIRED_SUBMODULES = (
+    "external/KernelWiki",
+    "external/ncu-report-skill",
+    "external/warp-specialization-report-skill",
+)
+_KNOWLEDGE_REQUIRED_PREFIXES = {
+    "kda_pilot": tuple(f"{path}/" for path in _KDA_REQUIRED_SUBMODULES),
+}
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _LOSSLESS_FORBIDDEN_ADDITIONS = re.compile(
     r"(?i)\b(?:step[-_ ]?skip|token[-_ ]?prun|spars|rank[-_ ]?reduc|"
@@ -1040,6 +1049,10 @@ class FileCampaignHooks:
             value = _read_object(route_path)
             profile_artifact = Path(value["profile_digest"])
             try:
+                if value.get("schema_version") != 2:
+                    raise ProfileError("route manifest predates target-aware routing")
+                if value.get("target_speedup") != self.goal.goal.target_speedup:
+                    raise ProfileError("route manifest target differs from frozen goal")
                 cached = ProfileDigest.model_validate_json(
                     profile_artifact.read_text(encoding="utf-8")
                 )
@@ -1075,6 +1088,7 @@ class FileCampaignHooks:
             digest,
             allow_quality_gated=self.goal.goal.allow_quality_gated,
             gpu_count=self.goal.hardware.gpu_count,
+            target_speedup=self.goal.goal.target_speedup,
         )
         unknown = set(routes) - set(self.registry.names())
         if unknown:
@@ -1084,8 +1098,10 @@ class FileCampaignHooks:
         _atomic_json(
             route_path,
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "routes": routes,
+                "route_policy": router.route_policy,
+                "target_speedup": self.goal.goal.target_speedup,
                 "evidence": router.last_evidence,
                 "profile_digest": str(profile_path),
                 "sglang_commit": locks["sglang"].commit,
@@ -1129,6 +1145,7 @@ class FileCampaignHooks:
         handles = self._epoch_handles(epoch)
         verified = self._load_verified(epoch)
         dispositions = self._load_dispositions()
+        deferred = self._load_deferred_lanes(epoch)
         baseline = BaselineRunner.load(self.campaign_dir / "BASELINE.json")
         quality = LockedSolQualityEvaluator(
             sol_checkout=self.campaign_dir / "source-worktrees" / "sol_engine",
@@ -1151,7 +1168,7 @@ class FileCampaignHooks:
         )
 
         for technique in routes:
-            if technique in verified or technique in dispositions:
+            if technique in verified or technique in dispositions or technique in deferred:
                 continue
             if technique not in handles:
                 active = self._ensure_next_executor(epoch)
@@ -1180,13 +1197,14 @@ class FileCampaignHooks:
                         )
                     except (OSError, ValueError, CampaignRuntimeError) as error:
                         return self._resume_or_exhaust(
-                            handle, f"Invalid DISPOSITION.json: {error}"
+                            handle, f"Invalid DISPOSITION.json: {error}", epoch=epoch
                         )
                     if disposition.classification == "blocked":
                         return self._resume_or_exhaust(
                             handle,
                             "A blocked disposition is recoverable and cannot close "
                             "the lane; repair the blocker or keep searching.",
+                            epoch=epoch,
                         )
                     self._store_disposition(disposition, disposition_path)
                     active = self._ensure_next_executor(epoch)
@@ -1201,6 +1219,7 @@ class FileCampaignHooks:
                     handle,
                     "The process exited without a regular DELIVERY.json inside "
                     "its assigned worktree.",
+                    epoch=epoch,
                 )
 
             result = verifier.verify(
@@ -1209,23 +1228,27 @@ class FileCampaignHooks:
                 executor_worktree=handle.worktree,
             )
             if not result.accepted:
-                if result.findings and all(
-                    finding.code in {"no_improvement", "dominated_memory"}
-                    for finding in result.findings
-                ):
+                for measurement in result.authenticated_measurements:
                     self._record_scientific_round(
                         handle,
                         polled.delivery,
-                        outcome="regressed",
+                        outcome=(
+                            "improved"
+                            if measurement.authoritative_speedup > 1.0
+                            else "regressed"
+                        ),
+                        measurement=measurement,
                     )
                 feedback = "\n".join(
                     f"{index}. [{finding.code}] {finding.message}"
                     for index, finding in enumerate(result.findings, start=1)
                 )
-                return self._resume_or_exhaust(handle, feedback)
+                return self._resume_or_exhaust(handle, feedback, epoch=epoch)
             if not result.verified_points:
                 return self._resume_or_exhaust(
-                    handle, "Verifier accepted no durable frontier point."
+                    handle,
+                    "Verifier accepted no durable frontier point.",
+                    epoch=epoch,
                 )
             point = max(
                 result.verified_points,
@@ -1235,6 +1258,14 @@ class FileCampaignHooks:
                 handle,
                 polled.delivery,
                 outcome="improved",
+                measurement=next(
+                    (
+                        item
+                        for item in result.authenticated_measurements
+                        if item.candidate_id == point.candidate_id
+                    ),
+                    None,
+                ),
             )
             manifest = point.implementation_manifest
             candidate = VerifiedCandidate(
@@ -1270,6 +1301,14 @@ class FileCampaignHooks:
 
         selected = self._selected_candidates(epoch)
         if not selected:
+            if self._load_deferred_lanes(epoch):
+                return StepResult(
+                    CampaignStatus.INFRA_BLOCKED,
+                    payload={
+                        "reason": "all_productive_lanes_finished_with_deferred_executors",
+                        "deferred_lanes": sorted(self._load_deferred_lanes(epoch)),
+                    },
+                )
             return StepResult(
                 CampaignStatus.SEARCH_SPACE_EXHAUSTED,
                 payload={"reason": "all_lanes_dispositioned_without_positive_candidate"},
@@ -1354,7 +1393,7 @@ class FileCampaignHooks:
             if handle is None:
                 self._ensure_next_executor(epoch, preferred=failed_technique)
             else:
-                outcome = self._resume_or_exhaust(handle, feedback)
+                outcome = self._resume_or_exhaust(handle, feedback, epoch=epoch)
                 if outcome.next_status is CampaignStatus.INFRA_BLOCKED:
                     return outcome
             return StepResult(
@@ -1788,8 +1827,20 @@ class FileCampaignHooks:
                     raise CampaignRuntimeError(
                         f"source worktree {name} is not at its locked commit"
                     )
+                if name == "kda_pilot":
+                    self.source_manager.ensure_submodules(
+                        destination,
+                        required=_KDA_REQUIRED_SUBMODULES,
+                    )
             else:
-                self.source_manager.create_worktree(lock, destination)
+                self.source_manager.create_worktree(
+                    lock,
+                    destination,
+                    initialize_submodules=name == "kda_pilot",
+                    required_submodules=(
+                        _KDA_REQUIRED_SUBMODULES if name == "kda_pilot" else ()
+                    ),
+                )
             roots[name] = destination.resolve()
         _validate_sol_contract(locks["sol_engine"], roots["sol_engine"])
         return roots
@@ -1806,13 +1857,33 @@ class FileCampaignHooks:
         for name, patterns in registry.items():
             lock = locks[name]
             output = self.campaign_dir / "knowledge" / name / lock.commit
-            snapshot = sync_source(
-                name=name,
-                checkout=worktrees[name],
-                commit=lock.commit,
-                patterns=patterns,
-                output_dir=output,
-            )
+            kwargs = {
+                "name": name,
+                "checkout": worktrees[name],
+                "commit": lock.commit,
+                "patterns": patterns,
+                "output_dir": output,
+                "required_prefixes": _KNOWLEDGE_REQUIRED_PREFIXES.get(name, ()),
+            }
+            try:
+                snapshot = sync_source(**kwargs)
+            except KnowledgeSyncError:
+                if not output.exists():
+                    raise
+                rejected_root = self.campaign_dir / "knowledge" / "rejected" / name
+                rejected_root.mkdir(parents=True, exist_ok=True)
+                digest = hashlib.sha256(
+                    (output / "index.json").read_bytes()
+                    if (output / "index.json").is_file()
+                    else str(output).encode()
+                ).hexdigest()[:12]
+                rejected = rejected_root / f"{lock.commit}-{digest}"
+                if rejected.exists():
+                    raise CampaignRuntimeError(
+                        f"knowledge recovery target already exists: {rejected}"
+                    )
+                output.replace(rejected)
+                snapshot = sync_source(**kwargs)
             if snapshot.commit != lock.commit:
                 raise CampaignRuntimeError(
                     f"knowledge snapshot {name} has the wrong commit"
@@ -1922,12 +1993,40 @@ class FileCampaignHooks:
                 "epoch": epoch,
                 "technique": technique,
                 "round_budget": self.registry[technique].round_budget,
+                "target_speedup": self.goal.goal.target_speedup,
+                "best_verified_speedup": self._best_verified_speedup(),
+                "remaining_multiplier": (
+                    self.goal.goal.target_speedup / self._best_verified_speedup()
+                ),
                 "prior_failures": self.store.failures(self.campaign_id),
             },
             rejected_signatures=tuple(
                 item["signature"] for item in self.store.failures(self.campaign_id)
             ),
+            delivery_contract=build_delivery_contract(
+                campaign=self.campaign_dir,
+                technique=technique,
+                registry=self.registry,
+                baseline=BaselineRunner.load(self.campaign_dir / "BASELINE.json"),
+                command_template=self._command_template(),
+            ),
         )
+
+    def _best_verified_speedup(self) -> float:
+        best = 1.0
+        path = self._candidate_registry_path()
+        if not path.is_file():
+            return best
+        for item in _read_object(path).get("history", []):
+            candidate = item.get("candidate") if isinstance(item, dict) else None
+            speedup = (
+                candidate.get("verified_speedup")
+                if isinstance(candidate, dict)
+                else None
+            )
+            if isinstance(speedup, (int, float)) and not isinstance(speedup, bool):
+                best = max(best, float(speedup))
+        return best
 
     def _epoch_handles(self, epoch: int) -> dict[str, ExecutorHandle]:
         root = self.campaign_dir / "search" / str(epoch)
@@ -1947,12 +2046,14 @@ class FileCampaignHooks:
         handles = self._epoch_handles(epoch)
         verified = self._load_verified(epoch)
         dispositions = self._load_dispositions()
+        deferred = self._load_deferred_lanes(epoch)
         active = manifest.get("active_technique")
         if (
             isinstance(active, str)
             and active in handles
             and active not in verified
             and active not in dispositions
+            and active not in deferred
         ):
             return active
 
@@ -1963,7 +2064,7 @@ class FileCampaignHooks:
             ordered.insert(0, preferred)
         selected: str | None = None
         for technique in ordered:
-            if technique in verified or technique in dispositions:
+            if technique in verified or technique in dispositions or technique in deferred:
                 continue
             rounds = self._technique_rounds(technique)
             if rounds >= self.registry[technique].round_budget:
@@ -2110,35 +2211,60 @@ class FileCampaignHooks:
         delivery_path: Path,
         *,
         outcome: str,
+        measurement: Any | None = None,
     ) -> str:
-        payload = _read_object(delivery_path)
-        points = payload.get("frontier_points")
-        if not isinstance(points, list) or not points or not isinstance(points[0], dict):
-            raise CampaignRuntimeError(
-                "cannot authenticate a scientific round without a frontier point"
-            )
-        point = points[0]
-        candidate_id = str(point.get("candidate_id", ""))
-        performance = point.get("performance")
-        if not candidate_id or not isinstance(performance, dict):
-            raise CampaignRuntimeError("scientific round delivery is incomplete")
+        if measurement is None:
+            payload = _read_object(delivery_path)
+            points = payload.get("frontier_points")
+            if (
+                not isinstance(points, list)
+                or not points
+                or not isinstance(points[0], dict)
+            ):
+                raise CampaignRuntimeError(
+                    "cannot authenticate a scientific round without a frontier point"
+                )
+            point = points[0]
+            candidate_id = str(point.get("candidate_id", ""))
+            performance = point.get("performance")
+            if not candidate_id or not isinstance(performance, dict):
+                raise CampaignRuntimeError("scientific round delivery is incomplete")
+            candidate_mean = performance.get("candidate_mean_e2e_s")
+            workload_total = performance.get("candidate_workload_total_s")
+            request_count = performance.get("request_count")
+            measurement_digest = sha256_file(delivery_path)
+            measurement_run = str(point.get("run_dir", ""))
+        else:
+            candidate_id = measurement.candidate_id
+            candidate_mean = measurement.candidate_mean_e2e_s
+            workload_total = measurement.candidate_workload_total_s
+            request_count = measurement.request_count
+            performance_path = measurement.run_dir / "PERFORMANCE.json"
+            measurement_digest = sha256_file(performance_path)
+            measurement_run = str(measurement.run_dir.resolve())
         round_id = hashlib.sha256(
-            f"{handle.technique}\0{candidate_id}\0{sha256_file(delivery_path)}".encode()
+            f"{handle.technique}\0{candidate_id}\0{measurement_run}\0"
+            f"{measurement_digest}".encode()
         ).hexdigest()[:20]
+        idempotency_key = f"{self.campaign_id}:scientific-round:{round_id}"
+        if any(
+            event["idempotency_key"] == idempotency_key
+            for event in self.store.events(self.campaign_id)
+        ):
+            return round_id
         self.store.record_event(
             self.campaign_id,
             "scientific_round_completed",
-            f"{self.campaign_id}:scientific-round:{round_id}",
+            idempotency_key,
             {
                 "round_id": round_id,
                 "technique": handle.technique,
                 "candidate_id": candidate_id,
                 "delivery_sha256": sha256_file(delivery_path),
-                "candidate_mean_e2e_s": performance.get("candidate_mean_e2e_s"),
-                "candidate_workload_total_s": performance.get(
-                    "candidate_workload_total_s"
-                ),
-                "request_count": performance.get("request_count"),
+                "candidate_mean_e2e_s": candidate_mean,
+                "candidate_workload_total_s": workload_total,
+                "request_count": request_count,
+                "measurement_sha256": measurement_digest,
                 "outcome": outcome,
             },
         )
@@ -2251,7 +2377,60 @@ class FileCampaignHooks:
         candidates.pop(technique, None)
         self._write_verified(epoch, candidates)
 
-    def _resume_or_exhaust(self, handle: ExecutorHandle, feedback: str) -> StepResult:
+    def _deferred_lanes_path(self, epoch: int) -> Path:
+        return self.campaign_dir / "search" / str(epoch) / "DEFERRED-LANES.json"
+
+    def _load_deferred_lanes(self, epoch: int) -> dict[str, dict[str, Any]]:
+        path = self._deferred_lanes_path(epoch)
+        if not path.is_file():
+            return {}
+        value = _read_object(path).get("lanes", {})
+        if not isinstance(value, dict):
+            raise CampaignRuntimeError("DEFERRED-LANES.json has invalid lanes")
+        return {
+            str(name): dict(payload)
+            for name, payload in value.items()
+            if isinstance(payload, dict)
+        }
+
+    def _defer_lane(
+        self,
+        epoch: int,
+        handle: ExecutorHandle,
+        *,
+        signature: str,
+        feedback: str,
+    ) -> None:
+        path = self._deferred_lanes_path(epoch)
+        payload = _read_object(path) if path.is_file() else {
+            "schema_version": 1,
+            "epoch": epoch,
+            "lanes": {},
+        }
+        payload["lanes"].setdefault(
+            handle.technique,
+            {
+                "executor_id": handle.executor_id,
+                "attempt": handle.attempt,
+                "failure_signature": signature,
+                "feedback": feedback,
+                "classification": "executor_protocol_deferred",
+            },
+        )
+        _atomic_json(path, payload)
+        manifest_path = self.campaign_dir / "search" / str(epoch) / "EXECUTORS.json"
+        manifest = _read_object(manifest_path)
+        if manifest.get("active_technique") == handle.technique:
+            manifest["active_technique"] = None
+            _atomic_json(manifest_path, manifest)
+
+    def _resume_or_exhaust(
+        self,
+        handle: ExecutorHandle,
+        feedback: str,
+        *,
+        epoch: int,
+    ) -> StepResult:
         budget = self.registry[handle.technique].round_budget
         rounds = self._technique_rounds(handle.technique)
         if rounds >= budget:
@@ -2276,14 +2455,35 @@ class FileCampaignHooks:
             event["idempotency_key"] == resume_key
             for event in self.store.events(self.campaign_id)
         )
-        if handle.attempt >= max(6, budget * 3) and not resume_already_recorded:
+        feedback_sha256 = hashlib.sha256(feedback.encode()).hexdigest()
+        same_signature_resumes = sum(
+            1
+            for event in self.store.events(
+                self.campaign_id,
+                event_type="executor_resumed",
+            )
+            if event["payload"].get("executor_id") == handle.executor_id
+            and event["payload"].get("feedback_sha256") == feedback_sha256
+        )
+        if (
+            (same_signature_resumes >= 2 or handle.attempt >= 6)
+            and not resume_already_recorded
+        ):
+            self._defer_lane(
+                epoch,
+                handle,
+                signature=signature,
+                feedback=feedback,
+            )
+            next_technique = self._ensure_next_executor(epoch)
             return StepResult(
-                CampaignStatus.INFRA_BLOCKED,
+                None,
                 payload={
-                    "reason": "executor_infrastructure_attempt_limit",
+                    "reason": "executor_lane_deferred",
                     "technique": handle.technique,
                     "attempt": handle.attempt,
                     "failure_signature": signature,
+                    "next_technique": next_technique,
                 },
             )
         resumed = self.executors.resume(

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/sources.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 
 from .models import SourceLock
@@ -92,7 +93,14 @@ class SourceManager:
             )
         return cache
 
-    def create_worktree(self, lock: SourceLock, destination: Path) -> Path:
+    def create_worktree(
+        self,
+        lock: SourceLock,
+        destination: Path,
+        *,
+        initialize_submodules: bool = False,
+        required_submodules: Sequence[str] = (),
+    ) -> Path:
         cache = self.checkout_path(lock)
         if destination.exists() or destination.is_symlink():
             raise FileExistsError(f"worktree destination already exists: {destination}")
@@ -119,8 +127,85 @@ class SourceManager:
             ],
             cwd=cache,
         )
-        self.assert_clean_worktree(resolved_destination)
+        try:
+            if initialize_submodules or required_submodules:
+                self.ensure_submodules(
+                    resolved_destination,
+                    required=required_submodules,
+                )
+            self.assert_clean_worktree(resolved_destination)
+        except BaseException:
+            run(
+                ["git", "worktree", "remove", "--force", str(resolved_destination)],
+                cwd=cache,
+                check=False,
+            )
+            raise
         return resolved_destination
+
+    def ensure_submodules(
+        self,
+        worktree: Path,
+        *,
+        required: Sequence[str],
+    ) -> None:
+        """Materialize and authenticate required submodules at pinned gitlinks."""
+        worktree = worktree.resolve()
+        normalized: list[str] = []
+        for value in required:
+            relative = Path(value)
+            if (
+                relative.is_absolute()
+                or ".." in relative.parts
+                or not relative.parts
+            ):
+                raise ValueError(f"unsafe required submodule path: {value!r}")
+            normalized.append(relative.as_posix())
+
+        if not normalized:
+            return
+        gitmodules = worktree / ".gitmodules"
+        if not gitmodules.is_file():
+            raise RuntimeError("required submodule metadata is missing: .gitmodules")
+        run(["git", "submodule", "sync", "--recursive"], cwd=worktree)
+        run(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "--",
+                *normalized,
+            ],
+            cwd=worktree,
+        )
+        for relative in normalized:
+            tree = run(
+                ["git", "ls-tree", "HEAD", "--", relative],
+                cwd=worktree,
+            ).stdout.strip()
+            match = re.fullmatch(
+                rf"160000 commit ([0-9a-f]{{40}})\t{re.escape(relative)}",
+                tree,
+            )
+            if match is None:
+                raise RuntimeError(
+                    f"required submodule is not a pinned gitlink: {relative}"
+                )
+            checkout = worktree / relative
+            if not checkout.is_dir():
+                raise RuntimeError(f"required submodule is missing: {relative}")
+            actual = run(["git", "rev-parse", "HEAD"], cwd=checkout).stdout.strip()
+            if actual != match.group(1):
+                raise RuntimeError(
+                    f"required submodule {relative} is at {actual}, "
+                    f"expected pinned gitlink {match.group(1)}"
+                )
+            if not any(path.name != ".git" for path in checkout.iterdir()):
+                raise RuntimeError(f"required submodule is empty: {relative}")
 
     def assert_clean_worktree(self, worktree: Path) -> None:
         status = run(

--- a/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py
+++ b/sgl-engine-sglang-diffusion/src/sgl_engine_sglang_diffusion/verifier.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol
 from pydantic import ValidationError
 
 from .agents import redact_argv, redact_environment
+from .knowledge import KnowledgeSyncError, snapshot_reference_files
 from .models import (
     BaselineRecord,
     CandidateManifest,
@@ -63,6 +64,20 @@ _RESIDENCY_EVIDENCE_NAMES = (
     "RESIDENCY-EVIDENCE.json",
     "residency-evidence.json",
 )
+_MEASUREMENT_INVALID_CODES = frozenset(
+    {
+        "invalid_run_dir",
+        "baseline_command_mismatch",
+        "missing_performance",
+        "missing_benchmark",
+        "missing_media",
+        "invalid_performance",
+        "invalid_benchmark_metrics",
+        "benchmark_performance_mismatch",
+        "timing_scope_mismatch",
+        "fallback_detected",
+    }
+)
 
 
 class VerificationError(RuntimeError):
@@ -114,11 +129,23 @@ class VerifiedFrontierPoint:
 
 
 @dataclass(frozen=True)
+class AuthenticatedMeasurement:
+    candidate_id: str
+    run_dir: Path
+    authoritative_speedup: float
+    candidate_mean_e2e_s: float
+    candidate_workload_total_s: float
+    request_count: int
+    peak_memory_mib: float
+
+
+@dataclass(frozen=True)
 class VerificationResult:
     accepted: bool
     technique: str
     findings: tuple[VerificationFinding, ...]
     verified_points: tuple[VerifiedFrontierPoint, ...]
+    authenticated_measurements: tuple[AuthenticatedMeasurement, ...]
     lossless_required: bool
 
 
@@ -164,12 +191,14 @@ class DeliveryVerifier:
         *,
         technique: str,
         executor_worktree: Path,
+        independent_gates: bool = True,
     ) -> VerificationResult:
         contract = self.registry[technique]
         lossless = contract.correctness == "lossless"
         worktree = executor_worktree.resolve()
         findings: list[VerificationFinding] = []
         verified: list[VerifiedFrontierPoint] = []
+        measurements: list[AuthenticatedMeasurement] = []
 
         try:
             durable_delivery = self._resolve_allowed(
@@ -189,6 +218,7 @@ class DeliveryVerifier:
                 technique=technique,
                 findings=tuple(findings),
                 verified_points=(),
+                authenticated_measurements=(),
                 lossless_required=lossless,
             )
 
@@ -214,21 +244,25 @@ class DeliveryVerifier:
             )
 
         for point in delivery.frontier_points:
-            point_findings, verified_point = self._verify_point(
+            point_findings, verified_point, measurement = self._verify_point(
                 point,
                 technique=technique,
                 lossless=lossless,
                 executor_worktree=worktree,
+                independent_gates=independent_gates,
             )
             findings.extend(point_findings)
             if not point_findings and verified_point is not None:
                 verified.append(verified_point)
+            if measurement is not None:
+                measurements.append(measurement)
 
         return VerificationResult(
             accepted=not findings and len(verified) == len(delivery.frontier_points),
             technique=technique,
             findings=tuple(findings),
             verified_points=tuple(verified),
+            authenticated_measurements=tuple(measurements),
             lossless_required=lossless,
         )
 
@@ -239,7 +273,12 @@ class DeliveryVerifier:
         technique: str,
         lossless: bool,
         executor_worktree: Path,
-    ) -> tuple[list[VerificationFinding], VerifiedFrontierPoint | None]:
+        independent_gates: bool,
+    ) -> tuple[
+        list[VerificationFinding],
+        VerifiedFrontierPoint | None,
+        AuthenticatedMeasurement | None,
+    ]:
         candidate_id = point.candidate_id
         issues: list[VerificationFinding] = []
 
@@ -258,7 +297,7 @@ class DeliveryVerifier:
                 )
         except VerificationError as error:
             issue("invalid_run_dir", str(error))
-            return issues, None
+            return issues, None, None
 
         artifacts: list[Path] = []
         for artifact in point.artifacts:
@@ -378,6 +417,7 @@ class DeliveryVerifier:
                 manifest=manifest,
                 technique=technique,
                 executor_worktree=executor_worktree,
+                independent_gates=independent_gates,
                 issue=issue,
             )
         else:
@@ -385,6 +425,7 @@ class DeliveryVerifier:
                 point,
                 run_dir=run_dir,
                 candidate_frames=candidate_frames,
+                independent_gates=independent_gates,
                 issue=issue,
             )
 
@@ -413,8 +454,22 @@ class DeliveryVerifier:
                 issue=issue,
             )
 
+        measurement: AuthenticatedMeasurement | None = None
+        if authoritative is not None and not any(
+            item.code in _MEASUREMENT_INVALID_CODES for item in issues
+        ):
+            speedup, candidate_mean, peak_memory = authoritative
+            measurement = AuthenticatedMeasurement(
+                candidate_id=candidate_id,
+                run_dir=run_dir,
+                authoritative_speedup=speedup,
+                candidate_mean_e2e_s=candidate_mean,
+                candidate_workload_total_s=candidate_mean * self.baseline.request_count,
+                request_count=self.baseline.request_count,
+                peak_memory_mib=peak_memory,
+            )
         if issues or authoritative is None or manifest is None:
-            return issues, None
+            return issues, None, measurement
         speedup, candidate_mean, peak_memory = authoritative
         return issues, VerifiedFrontierPoint(
             candidate_id=candidate_id,
@@ -425,7 +480,7 @@ class DeliveryVerifier:
             activation=dict(point.activation),
             implementation_manifest=manifest,
             source_hashes=dict(source_hashes),
-        )
+        ), measurement
 
     def _verify_kernel_evidence(
         self,
@@ -635,31 +690,19 @@ class DeliveryVerifier:
             if not isinstance(raw_index, str):
                 raise VerificationError("campaign has no pinned KDA-Pilot snapshot")
             index_path = self._resolve_allowed(Path(raw_index), (knowledge_root,))
-            index = self._json_object(index_path)
-            entries = index.get("entries")
-            if not isinstance(entries, list):
-                raise VerificationError("KDA-Pilot knowledge index has no entries")
-        except (OSError, VerificationError) as error:
-            raise VerificationError(f"cannot load pinned KernelWiki index: {error}") from error
-        result: dict[Path, str] = {}
-        for entry in entries:
-            if not isinstance(entry, Mapping):
-                continue
-            relative = entry.get("path")
-            digest = entry.get("reference_sha256")
-            if (
-                not isinstance(relative, str)
-                or not relative.startswith("external/KernelWiki/")
-                or not isinstance(digest, str)
-            ):
-                continue
-            reference = self._resolve_allowed(
-                index_path.parent / "references" / relative,
-                (knowledge_root,),
+            result = snapshot_reference_files(
+                index_path,
+                prefix="external/KernelWiki",
             )
-            result[reference] = digest
-        if not result:
-            raise VerificationError("pinned KDA-Pilot snapshot contains no KernelWiki files")
+        except (OSError, KnowledgeSyncError, VerificationError) as error:
+            raise VerificationError(f"cannot load pinned KernelWiki index: {error}") from error
+        for path in result:
+            try:
+                path.relative_to(knowledge_root.resolve())
+            except ValueError as error:
+                raise VerificationError(
+                    "pinned KernelWiki reference escapes knowledge root"
+                ) from error
         return result
 
     @staticmethod
@@ -868,6 +911,7 @@ class DeliveryVerifier:
         manifest: CandidateManifest | None,
         technique: str,
         executor_worktree: Path,
+        independent_gates: bool,
         issue: Any,
     ) -> None:
         try:
@@ -898,6 +942,8 @@ class DeliveryVerifier:
 
         if manifest is None:
             return
+        if not independent_gates:
+            return
         try:
             result = self.method_auditor.audit(
                 technique=technique,
@@ -917,6 +963,7 @@ class DeliveryVerifier:
         *,
         run_dir: Path,
         candidate_frames: Path,
+        independent_gates: bool,
         issue: Any,
     ) -> None:
         if point.quality.mode != "quality_gated":
@@ -925,6 +972,8 @@ class DeliveryVerifier:
             )
         if point.quality.lpips_mean is None or point.quality.lpips_max is None:
             issue("missing_lpips", "quality-gated point requires aligned LPIPS metrics")
+        if not independent_gates:
+            return
         if self.quality_evaluator is None:
             issue(
                 "missing_quality_evaluator",

--- a/sgl-engine-sglang-diffusion/techniques/kernel.md
+++ b/sgl-engine-sglang-diffusion/techniques/kernel.md
@@ -80,6 +80,13 @@ manifest and source hashes, engagement/fallback counters, warmup policy, timing
 scope, compile/init cost, and a real full-workload run.
 
 Microbenchmarks screen implementations but cannot establish end-to-end speedup.
+Use the current target gap to avoid spending a five-prompt run on a candidate
+whose targeted screen shows negligible impact, unless it is essentially free,
+is needed as a composable primitive, or closes required coverage. Record the
+screened hypothesis instead of repeatedly measuring equivalent flag variants.
+The candidate commit must change production-consumed source; run artifacts,
+evidence JSON, or a configuration file that is not wired into execution cannot
+serve as the implementation patch.
 Retain only measurable latency improvements or non-dominated peak-memory points.
 Maintain a cumulative ON stack and periodically rerun its full-DiT and complete
 frozen-workload gate. Delivery contains the fastest measured exact composed
@@ -88,3 +95,7 @@ stack plus its method-equivalence argument and unchanged logical counts.
 Deliver at round 60, after a genuine multi-hypothesis plateau, or after a target
 is reached and fully gated. A target is search pressure, not an acceptance rule
 or proof of reachability.
+
+Use the controller-generated `DELIVERY-CONTRACT.json` for exact schemas,
+required artifacts, profile/baseline bindings, and pinned KernelWiki citation
+paths. Run its static preflight command before returning control.

--- a/sgl-engine-sglang-diffusion/tests/test_cli.py
+++ b/sgl-engine-sglang-diffusion/tests/test_cli.py
@@ -3,7 +3,25 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sgl_engine_sglang_diffusion.cli import main
+from sgl_engine_sglang_diffusion.cli import build_parser, main
+
+
+def test_preflight_delivery_cli_requires_explicit_campaign_and_worktree() -> None:
+    args = build_parser().parse_args(
+        [
+            "preflight-delivery",
+            "--campaign",
+            "/tmp/campaign",
+            "--technique",
+            "kernel",
+            "--executor-worktree",
+            "/tmp/worktree",
+            "--delivery",
+            "/tmp/worktree/DELIVERY.json",
+        ]
+    )
+    assert args.command == "preflight-delivery"
+    assert args.technique == "kernel"
 
 
 def test_init_and_status_are_cpu_only(tmp_path: Path, capsys: object) -> None:

--- a/sgl-engine-sglang-diffusion/tests/test_delivery_contract.py
+++ b/sgl-engine-sglang-diffusion/tests/test_delivery_contract.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from sgl_engine_sglang_diffusion.delivery_contract import (
+    build_delivery_contract,
+    materialize_delivery_contract,
+)
+from sgl_engine_sglang_diffusion.models import BaselineRecord
+from sgl_engine_sglang_diffusion.techniques import TechniqueRegistry
+
+
+def test_kernel_contract_exposes_exact_pinned_citations_and_schemas(
+    tmp_path: Path,
+) -> None:
+    campaign = tmp_path / "campaign"
+    profile = campaign / "profiles/0/PROFILE-DIGEST.json"
+    profile.parent.mkdir(parents=True)
+    profile.write_text('{"profile":"bound"}\n')
+    baseline_path = campaign / "BASELINE.json"
+    baseline_path.write_text('{"baseline":"bound"}\n')
+    inventory_path = campaign / "GPU-INVENTORY.json"
+    inventory_path.write_text('{"gpu_count":1}\n')
+    reference = (
+        campaign
+        / "knowledge/kda_pilot/locked/references/external/KernelWiki/wiki/fusion.md"
+    )
+    reference.parent.mkdir(parents=True)
+    reference.write_text("# Fusion\n")
+    digest = hashlib.sha256(reference.read_bytes()).hexdigest()
+    index = campaign / "knowledge/kda_pilot/locked/index.json"
+    index.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source": "kda_pilot",
+                "commit": "d" * 40,
+                "entries": [
+                    {
+                        "path": "external/KernelWiki/wiki/fusion.md",
+                        "media_type": "text/markdown",
+                        "sha256": digest,
+                        "reference_sha256": digest,
+                        "headings": ["Fusion"],
+                        "symbols": [],
+                        "executable": False,
+                    }
+                ],
+            }
+        )
+    )
+    (campaign / "KNOWLEDGE.json").write_text(
+        json.dumps({"schema_version": 1, "snapshots": {"kda_pilot": str(index)}})
+    )
+    baseline = BaselineRecord(
+        model_id="test/model",
+        mean_e2e_s=10.0,
+        workload_total_s=50.0,
+        request_count=5,
+        peak_memory_mib=1000.0,
+        timing_scope="frozen_e2e",
+        run_dir=campaign / "baseline/run",
+        baseline_frames=campaign / "baseline/frames",
+        sglang_commit="a" * 40,
+    )
+    root = Path(__file__).resolve().parents[1]
+    registry = TechniqueRegistry.load(root / "techniques/registry.toml")
+
+    contract = build_delivery_contract(
+        campaign=campaign,
+        technique="kernel",
+        registry=registry,
+        baseline=baseline,
+        command_template=None,
+    )
+    worktree = tmp_path / "executor/worktree"
+    delivery = worktree / "DELIVERY.json"
+    materialized = materialize_delivery_contract(
+        contract,
+        worktree=worktree,
+        delivery=delivery,
+    )
+
+    assert materialized["delivery_path"] == str(delivery.resolve())
+    assert materialized["schemas"]["delivery"]["title"] == "Delivery"
+    assert materialized["schemas"]["technique_evidence"]["title"] == (
+        "KernelEvidence"
+    )
+    assert materialized["pinned_kernelwiki_sources"] == [
+        {"path": str(reference.resolve()), "sha256": digest}
+    ]
+    assert materialized["performance_artifact_required_fields"]["request_count"] == 5
+    assert materialized["preflight_argv"][-1] == str(delivery.resolve())
+    assert materialized["gpu_inventory"] == {
+        "path": str(inventory_path),
+        "sha256": hashlib.sha256(inventory_path.read_bytes()).hexdigest(),
+    }

--- a/sgl-engine-sglang-diffusion/tests/test_integration_flow.py
+++ b/sgl-engine-sglang-diffusion/tests/test_integration_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -267,8 +268,10 @@ def test_unverified_candidate_is_rejected_before_worktree_creation(
 
 
 def test_composition_is_canonical_and_does_not_modify_candidate_repository(
-    tmp_path: Path, fake_git_repo: Path
+    tmp_path: Path, fake_git_repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     kernel_commit = _commit(
         fake_git_repo, "kernel-candidate", {"kernel.txt": "kernel\n"}
     )

--- a/sgl-engine-sglang-diffusion/tests/test_knowledge.py
+++ b/sgl-engine-sglang-diffusion/tests/test_knowledge.py
@@ -115,6 +115,80 @@ def test_snapshot_is_idempotent_for_same_source_lock(tmp_path: Path) -> None:
     assert first == second
 
 
+def test_snapshot_requires_entries_and_required_prefixes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "README.md").write_text("# KDA\n")
+    commit = _commit_all(repo, "knowledge")
+
+    with pytest.raises(KnowledgeSyncError, match="no allowlisted files"):
+        sync_source(
+            name="kda_pilot",
+            checkout=repo,
+            commit=commit,
+            patterns=["missing/**"],
+            required_prefixes=("external/KernelWiki/",),
+            output_dir=tmp_path / "empty",
+        )
+
+    with pytest.raises(KnowledgeSyncError, match="required knowledge prefix"):
+        sync_source(
+            name="kda_pilot",
+            checkout=repo,
+            commit=commit,
+            patterns=["README.md"],
+            required_prefixes=("external/KernelWiki/",),
+            output_dir=tmp_path / "incomplete",
+        )
+
+
+def test_reused_snapshot_revalidates_reference_digest(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "allowed.md").write_text("# Stable\n")
+    commit = _commit_all(repo, "knowledge")
+    output = tmp_path / "out"
+    sync_source(
+        name="fake",
+        checkout=repo,
+        commit=commit,
+        patterns=["allowed.md"],
+        output_dir=output,
+    )
+    (output / "references/allowed.md").write_text("tampered\n")
+
+    with pytest.raises(KnowledgeSyncError, match="digest"):
+        sync_source(
+            name="fake",
+            checkout=repo,
+            commit=commit,
+            patterns=["allowed.md"],
+            output_dir=output,
+        )
+
+
+def test_reused_snapshot_reports_corrupt_index_as_recoverable(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "allowed.md").write_text("# Stable\n")
+    commit = _commit_all(repo, "knowledge")
+    output = tmp_path / "out"
+    sync_source(
+        name="fake",
+        checkout=repo,
+        commit=commit,
+        patterns=["allowed.md"],
+        output_dir=output,
+    )
+    (output / "index.json").write_text("{broken\n")
+
+    with pytest.raises(KnowledgeSyncError, match="knowledge index is invalid"):
+        sync_source(
+            name="fake",
+            checkout=repo,
+            commit=commit,
+            patterns=["allowed.md"],
+            output_dir=output,
+        )
+
+
 def test_snapshot_refuses_different_commit_in_existing_output(
     tmp_path: Path,
 ) -> None:

--- a/sgl-engine-sglang-diffusion/tests/test_orchestration.py
+++ b/sgl-engine-sglang-diffusion/tests/test_orchestration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from sgl_engine_sglang_diffusion.agents import AgentRunner
+from sgl_engine_sglang_diffusion.agents import AgentRunner, build_agent_argv
 from sgl_engine_sglang_diffusion.orchestration import (
     ExecutorManager,
     ExecutorPrompt,
@@ -70,6 +70,21 @@ def _prompt() -> ExecutorPrompt:
         search_state={"round": 1, "frontier": []},
         rejected_signatures=("prior-failure",),
     )
+
+
+def test_codex_exec_is_noninteractive_and_writable(tmp_path: Path) -> None:
+    prompt = tmp_path / "goal.md"
+    prompt.write_text("do the task\n")
+
+    argv = build_agent_argv(["codex", "exec"], None, prompt)
+
+    assert argv == [
+        "codex",
+        "exec",
+        "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+        str(prompt),
+    ]
 
 
 def _manager(

--- a/sgl-engine-sglang-diffusion/tests/test_orchestration.py
+++ b/sgl-engine-sglang-diffusion/tests/test_orchestration.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from sgl_engine_sglang_diffusion.agents import AgentRunner, build_agent_argv
+from sgl_engine_sglang_diffusion.agents import (
+    AgentRunner,
+    build_agent_argv,
+    read_codex_thread_id,
+)
 from sgl_engine_sglang_diffusion.orchestration import (
     ExecutorManager,
     ExecutorPrompt,
@@ -43,7 +47,9 @@ time.sleep(float(os.environ.get("FAKE_AGENT_DELAY", "0.02")))
     return script
 
 
-def _prompt() -> ExecutorPrompt:
+def _prompt(
+    *, delivery_contract: dict[str, object] | None = None
+) -> ExecutorPrompt:
     return ExecutorPrompt(
         correctness_contract=PromptSection(
             "Sol correctness", "correctness contract\n", "locked:sol"
@@ -69,6 +75,7 @@ def _prompt() -> ExecutorPrompt:
         ),
         search_state={"round": 1, "frontier": []},
         rejected_signatures=("prior-failure",),
+        delivery_contract=delivery_contract,
     )
 
 
@@ -85,6 +92,130 @@ def test_codex_exec_is_noninteractive_and_writable(tmp_path: Path) -> None:
         "--dangerously-bypass-approvals-and-sandbox",
         str(prompt),
     ]
+
+
+def test_codex_resume_uses_exact_persisted_thread(tmp_path: Path) -> None:
+    prompt = tmp_path / "feedback.md"
+    prompt.write_text("repair the delivery\n")
+    thread_id = "67e55044-10b1-426f-9247-bb680e5fe0c8"
+
+    argv = build_agent_argv(
+        ["codex", "exec"],
+        "gpt-test",
+        prompt,
+        resume_session_id=thread_id,
+    )
+
+    assert argv == [
+        "codex",
+        "exec",
+        "resume",
+        "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--model",
+        "gpt-test",
+        thread_id,
+        str(prompt),
+    ]
+
+
+def test_codex_thread_id_is_read_from_jsonl_and_conflicts_fail(tmp_path: Path) -> None:
+    stream = tmp_path / "stdout.log"
+    thread_id = "67e55044-10b1-426f-9247-bb680e5fe0c8"
+    stream.write_text(
+        json.dumps({"type": "thread.started", "thread_id": thread_id}) + "\n"
+    )
+    assert read_codex_thread_id(stream) == thread_id
+
+    stream.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": thread_id}),
+                json.dumps({"type": "thread.started", "thread_id": "different"}),
+            ]
+        )
+        + "\n"
+    )
+    with pytest.raises(Exception, match="conflicting"):
+        read_codex_thread_id(stream)
+
+
+def test_executor_resume_continues_same_codex_thread_with_compact_feedback(
+    fake_git_repo: Path, tmp_path: Path
+) -> None:
+    codex = tmp_path / "codex"
+    codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+thread_id = "67e55044-10b1-426f-9247-bb680e5fe0c8"
+print(json.dumps({"type": "thread.started", "thread_id": thread_id}), flush=True)
+prompt = Path(sys.argv[-1]).read_text(encoding="utf-8")
+match = re.search(r"^Required delivery path: (.+)$", prompt, re.MULTILINE)
+if match is None:
+    raise SystemExit("missing delivery path")
+Path(match.group(1)).write_text('{"status":"complete"}\\n')
+""",
+        encoding="utf-8",
+    )
+    codex.chmod(0o755)
+    state = StateStore.open(tmp_path / "state.sqlite", tmp_path / "events.jsonl")
+    state.create_campaign("campaign-1")
+    sources = SourceManager(tmp_path / "sources")
+    lock = sources.lock("sglang", str(fake_git_repo), "main")
+    manager = ExecutorManager(
+        tmp_path / "run",
+        state=state,
+        sources=sources,
+        runner=AgentRunner([str(codex), "exec"]),
+    )
+    try:
+        first = manager.spawn(
+            campaign_id="campaign-1",
+            technique="kernel",
+            source_lock=lock,
+            prompt=_prompt(
+                delivery_contract={
+                    "schema_version": 1,
+                    "executor_worktree": "{{executor_worktree}}",
+                    "delivery_path": "{{delivery_path}}",
+                    "preflight_argv": [
+                        "sgl-diffusion-engine",
+                        "preflight-delivery",
+                        "--executor-worktree",
+                        "{{executor_worktree}}",
+                        "--delivery",
+                        "{{delivery_path}}",
+                    ],
+                }
+            ),
+            idempotency_key="spawn-kernel",
+        )
+        _wait_until_stopped(manager, first)
+        resumed = manager.resume(
+            first,
+            feedback="[invalid_kernel_evidence] use the pinned citation",
+            idempotency_key="resume-kernel",
+        )
+
+        session = json.loads((first.root / "SESSION.json").read_text())
+        receipt = json.loads(resumed.receipt.read_text())
+        assert session["thread_id"] == "67e55044-10b1-426f-9247-bb680e5fe0c8"
+        assert receipt["agent_session_mode"] == "resume"
+        assert receipt["resumed_thread_id"] == session["thread_id"]
+        assert "resume" in receipt["argv"]
+        assert session["thread_id"] in receipt["argv"]
+        compact = resumed.prompt.read_text()
+        assert "invalid_kernel_evidence" in compact
+        assert "Sol correctness" not in compact
+        assert "preflight-delivery" in compact
+        assert str(first.worktree) in compact
+    finally:
+        manager.close()
+        state.close()
 
 
 def _manager(

--- a/sgl-engine-sglang-diffusion/tests/test_orchestration.py
+++ b/sgl-engine-sglang-diffusion/tests/test_orchestration.py
@@ -118,7 +118,53 @@ def _manager(
             "HF_TOKEN": "environment-secret",
         },
     )
+    assert manager.agent_environment["GIT_AUTHOR_NAME"] == (
+        "sgl-diffusion-engine executor"
+    )
+    assert manager.agent_environment["GIT_AUTHOR_EMAIL"] == (
+        "sgl-diffusion-engine@localhost"
+    )
+    assert manager.agent_environment["GIT_COMMITTER_NAME"] == (
+        "sgl-diffusion-engine executor"
+    )
+    assert manager.agent_environment["GIT_COMMITTER_EMAIL"] == (
+        "sgl-diffusion-engine@localhost"
+    )
     return manager, state, lock
+
+
+def test_executor_git_identity_respects_explicit_environment(
+    fake_git_repo: Path, tmp_path: Path
+) -> None:
+    state = StateStore.open(tmp_path / "state.sqlite", tmp_path / "events.jsonl")
+    sources = SourceManager(tmp_path / "sources")
+    runner = AgentRunner([sys.executable, str(_fake_agent(tmp_path))])
+    manager = ExecutorManager(
+        tmp_path / "run",
+        state=state,
+        sources=sources,
+        runner=runner,
+        agent_environment={
+            "GIT_AUTHOR_NAME": "Explicit Author",
+            "GIT_AUTHOR_EMAIL": "author@example.test",
+            "GIT_COMMITTER_NAME": "Explicit Committer",
+            "GIT_COMMITTER_EMAIL": "committer@example.test",
+        },
+    )
+    try:
+        assert manager.agent_environment["GIT_AUTHOR_NAME"] == "Explicit Author"
+        assert manager.agent_environment["GIT_AUTHOR_EMAIL"] == (
+            "author@example.test"
+        )
+        assert manager.agent_environment["GIT_COMMITTER_NAME"] == (
+            "Explicit Committer"
+        )
+        assert manager.agent_environment["GIT_COMMITTER_EMAIL"] == (
+            "committer@example.test"
+        )
+    finally:
+        manager.close()
+        state.close()
 
 
 def _wait_until_stopped(manager: ExecutorManager, handle: object) -> None:

--- a/sgl-engine-sglang-diffusion/tests/test_profiler.py
+++ b/sgl-engine-sglang-diffusion/tests/test_profiler.py
@@ -141,7 +141,12 @@ def test_profiler_preserves_trace_and_normalizes_summary(tmp_path: Path) -> None
 def test_profile_routes_attention_and_glue_hotspots(tmp_path: Path) -> None:
     digest = make_profile_digest(tmp_path)
     router = TechniqueRouter()
-    routed = router.route(digest, allow_quality_gated=True, gpu_count=1)
+    routed = router.route(
+        digest,
+        allow_quality_gated=True,
+        gpu_count=1,
+        target_speedup=2.0,
+    )
     assert routed == [
         "residency",
         "kernel",
@@ -158,8 +163,45 @@ def test_profile_routes_attention_and_glue_hotspots(tmp_path: Path) -> None:
 
 def test_profile_freezes_parallel_topology_for_multi_gpu(tmp_path: Path) -> None:
     digest = make_profile_digest(tmp_path)
-    routed = TechniqueRouter().route(digest, allow_quality_gated=False, gpu_count=4)
+    routed = TechniqueRouter().route(
+        digest,
+        allow_quality_gated=False,
+        gpu_count=4,
+        target_speedup=5.0,
+    )
     assert routed == ["residency", "kernel"]
+
+
+def test_large_quality_gated_target_prioritizes_high_leverage_lanes(
+    tmp_path: Path,
+) -> None:
+    digest = make_profile_digest(tmp_path)
+    router = TechniqueRouter()
+
+    routed = router.route(
+        digest,
+        allow_quality_gated=True,
+        gpu_count=4,
+        target_speedup=5.0,
+    )
+
+    assert routed == [
+        "residency",
+        "cache",
+        "pisa",
+        "quantization",
+        "token_pruning",
+        "kernel",
+    ]
+    assert router.route_policy == "large-gap-quality-first-v1"
+
+    router.route(
+        digest,
+        allow_quality_gated=False,
+        gpu_count=4,
+        target_speedup=2.0,
+    )
+    assert router.route_policy == "lossless-first-v1"
 
 
 def test_profile_rejects_corrupt_or_event_empty_raw_trace(tmp_path: Path) -> None:

--- a/sgl-engine-sglang-diffusion/tests/test_progress.py
+++ b/sgl-engine-sglang-diffusion/tests/test_progress.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from sgl_engine_sglang_diffusion.cli import initialize
+from sgl_engine_sglang_diffusion.models import CampaignStatus
 from sgl_engine_sglang_diffusion.progress import render_progress, write_progress
 from sgl_engine_sglang_diffusion.state import StateStore
 
@@ -173,3 +174,38 @@ def test_progress_reports_tokens_techniques_and_nonadditive_stack(
     assert "50.0000s/5 requests baseline" in rendered
     assert "29.7619s/5 requests integrated" in rendered
     assert (campaign / "PROGRESS.json").is_file()
+
+
+def test_progress_marks_only_manifest_active_lane_as_running(tmp_path: Path) -> None:
+    campaign = make_campaign(tmp_path)
+    manifest = json.loads((campaign / "CAMPAIGN.json").read_text())
+    campaign_id = manifest["campaign_id"]
+    with StateStore.open(campaign / "state.sqlite", campaign / "events.jsonl") as store:
+        for status in (
+            CampaignStatus.BASELINE_LOCKED,
+            CampaignStatus.PROFILED,
+            CampaignStatus.SEARCHING,
+        ):
+            store.transition(
+                campaign_id,
+                status,
+                idempotency_key=f"to-{status.value}",
+            )
+        for technique in ("kernel", "cache"):
+            store.record_event(
+                campaign_id,
+                "executor_spawned",
+                f"spawn-{technique}",
+                {"executor_id": technique, "technique": technique, "attempt": 1},
+            )
+    search = campaign / "search/0"
+    search.mkdir(parents=True)
+    (search / "EXECUTORS.json").write_text(
+        json.dumps({"active_technique": "cache", "executors": {}})
+    )
+
+    progress = write_progress(campaign)
+    states = {item["technique"]: item["status"] for item in progress["techniques"]}
+
+    assert states["kernel"] == "attempted"
+    assert states["cache"] == "running"

--- a/sgl-engine-sglang-diffusion/tests/test_request.py
+++ b/sgl-engine-sglang-diffusion/tests/test_request.py
@@ -151,6 +151,54 @@ def test_normalize_rejects_model_or_prompt_contract_drift(tmp_path: Path) -> Non
     with pytest.raises(RequestError, match="five"):
         normalize_launch_request(request)
 
+    request = make_request(tmp_path, native_command())
+    prompts = tmp_path / "sglang" / "prompts.txt"
+    prompts.write_text("\n".join(f"prompt {index}" for index in range(6)) + "\n")
+    with pytest.raises(RequestError, match="exactly five"):
+        normalize_launch_request(request)
+
+
+def test_h3_canonical_workload_and_gpu_count_are_frozen(tmp_path: Path) -> None:
+    command = (
+        native_command()
+        + " --backend sglang --batch-size 1 --num-gpus 4 --ulysses-degree 4"
+        + " --minimax-h3-task t2va --minimax-h3-conditions-json '[]'"
+        + " --minimax-h3-target-json "
+        + "'{\"short_edge\":768,\"aspect_ratio\":\"16:9\","
+        + "\"duration_seconds\":5.0}'"
+        + " --flow-shift 12.0 --audio-flow-shift 3.0"
+    )
+    goal, template = normalize_launch_request(make_request(tmp_path, command))
+
+    assert template.parallel_flags == {
+        "--num-gpus": "4",
+        "--ulysses-degree": "4",
+    }
+    assert template.frozen_flags["--backend"] == "sglang"
+    assert template.frozen_flags["--batch-size"] == "1"
+    assert template.frozen_flags["--minimax-h3-task"] == "t2va"
+    assert template.frozen_flags["--minimax-h3-conditions-json"] == "[]"
+    assert template.frozen_flags["--flow-shift"] == "12.0"
+    assert template.frozen_flags["--audio-flow-shift"] == "3.0"
+
+    for activation_args in (
+        ("--backend", "diffusers"),
+        ("--batch-size", "2"),
+        ("--num-gpus", "2"),
+        ("--minimax-h3-task", "ref2va"),
+        ("--flow-shift", "8.0"),
+        ("--performance-mode", "speed"),
+        ("--skip-warmup",),
+    ):
+        with pytest.raises(RequestError, match="frozen|parallel"):
+            template.render(
+                checkout=tmp_path / "sglang",
+                prompts=goal.workload.prompts,
+                output_file=tmp_path / "output.jsonl",
+                media_dir=tmp_path / "media",
+                activation_args=activation_args,
+            )
+
 
 def test_module_entrypoint_is_supported(tmp_path: Path) -> None:
     command = native_command().replace(

--- a/sgl-engine-sglang-diffusion/tests/test_runtime_e2e.py
+++ b/sgl-engine-sglang-diffusion/tests/test_runtime_e2e.py
@@ -545,6 +545,37 @@ delivery_path.write_text(json.dumps(delivery, sort_keys=True))
 """
 
 
+def _add_fixture_submodule(
+    repository: Path,
+    tmp_path: Path,
+    submodule_path: str,
+    files: dict[str, str],
+) -> None:
+    source = tmp_path / f"{Path(submodule_path).name}-upstream"
+    source.mkdir()
+    run(["git", "init"], cwd=source)
+    run(["git", "config", "user.email", "tests@example.invalid"], cwd=source)
+    run(["git", "config", "user.name", "Test Author"], cwd=source)
+    for relative, content in files.items():
+        path = source / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    run(["git", "add", "."], cwd=source)
+    run(["git", "commit", "-m", "fixture knowledge"], cwd=source)
+    run(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(source),
+            submodule_path,
+        ],
+        cwd=repository,
+    )
+
+
 def _prepare_fake_source(repository: Path, tmp_path: Path) -> Path:
     benchmark = (
         repository
@@ -567,10 +598,32 @@ def _prepare_fake_source(repository: Path, tmp_path: Path) -> Path:
     (repository / "docs/inference/optimizations.md").write_text("fake optimization\n")
     (repository / "diffusion/docs").mkdir(parents=True)
     (repository / "diffusion/docs/optimization.md").write_text("fake KDA note\n")
-    (repository / "external/KernelWiki/wiki/techniques").mkdir(parents=True)
-    (repository / "external/KernelWiki/SKILL.md").write_text("# KernelWiki fixture\n")
-    (repository / "external/KernelWiki/wiki/techniques/kernel-fusion.md").write_text(
-        "# Kernel fusion fixture\n"
+    _add_fixture_submodule(
+        repository,
+        tmp_path,
+        "external/KernelWiki",
+        {
+            "SKILL.md": "# KernelWiki fixture\n",
+            "wiki/techniques/kernel-fusion.md": "# Kernel fusion fixture\n",
+        },
+    )
+    _add_fixture_submodule(
+        repository,
+        tmp_path,
+        "external/ncu-report-skill",
+        {
+            "SKILL.md": "# NCU report fixture\n",
+            "reference/metrics.md": "# NCU metrics fixture\n",
+        },
+    )
+    _add_fixture_submodule(
+        repository,
+        tmp_path,
+        "external/warp-specialization-report-skill",
+        {
+            "SKILL.md": "# Warp specialization fixture\n",
+            "helpers/README.md": "# Warp specialization helper fixture\n",
+        },
     )
     (repository / "search").mkdir()
     (repository / "search/plan_eval.py").write_text(

--- a/sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py
+++ b/sgl-engine-sglang-diffusion/tests/test_runtime_scheduler.py
@@ -63,9 +63,25 @@ def test_executor_prompt_injects_only_active_lane_history_rules(
     (campaign / "KNOWLEDGE.json").write_text(
         json.dumps({"schema_version": 1, "snapshots": {}})
     )
+    baseline_run = campaign / "baseline/run"
+    baseline_frames = campaign / "baseline/frames"
+    baseline_run.mkdir(parents=True)
+    baseline_frames.mkdir(parents=True)
     (campaign / "BASELINE.json").write_text(
-        '{"schema_version": 2, "mean_e2e_s": 10.0, '
-        '"workload_total_s": 50.0, "request_count": 5}\n'
+        json.dumps(
+            {
+                "schema_version": 2,
+                "model_id": "test/model",
+                "mean_e2e_s": 10.0,
+                "workload_total_s": 50.0,
+                "request_count": 5,
+                "peak_memory_mib": 1024.0,
+                "timing_scope": "frozen_e2e",
+                "run_dir": str(baseline_run),
+                "baseline_frames": str(baseline_frames),
+                "sglang_commit": "a" * 40,
+            }
+        )
     )
     (campaign / "profiles/0/PROFILE-DIGEST.json").write_text(
         '{"profile": "bound"}\n'
@@ -79,7 +95,10 @@ def test_executor_prompt_injects_only_active_lane_history_rules(
     hooks = object.__new__(FileCampaignHooks)
     hooks.campaign_dir = campaign
     hooks.campaign_id = "campaign-1"
-    hooks.goal = SimpleNamespace(model=SimpleNamespace(id="test/model"))
+    hooks.goal = SimpleNamespace(
+        model=SimpleNamespace(id="test/model"),
+        goal=SimpleNamespace(target_speedup=5.0),
+    )
     hooks.store = store
     hooks.registry = TechniqueRegistry.load(
         Path(__file__).resolve().parents[1] / "techniques/registry.toml"
@@ -286,5 +305,73 @@ def test_lane_disposition_requires_complete_coverage_not_one_failed_hypothesis(
         disposition.write_text(json.dumps(payload))
         with pytest.raises(CampaignRuntimeError, match="exact required"):
             hooks._validate_disposition(disposition, "kernel")
+    finally:
+        store.close()
+
+
+def test_repeated_executor_protocol_failure_defers_lane_and_advances(
+    tmp_path: Path,
+) -> None:
+    campaign = tmp_path / "campaign"
+    search = campaign / "search/1"
+    search.mkdir(parents=True)
+    (search / "EXECUTORS.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "epoch": 1,
+                "routes": ["kernel", "cache"],
+                "executors": {},
+                "active_technique": "kernel",
+            }
+        )
+    )
+    store = StateStore.open(campaign / "state.sqlite", campaign / "events.jsonl")
+    store.create_campaign("campaign-1")
+    feedback = "[invalid_kernel_evidence] citation is outside pinned knowledge"
+    feedback_sha256 = hashlib.sha256(feedback.encode()).hexdigest()
+    for attempt in (2, 3):
+        store.record_event(
+            "campaign-1",
+            "executor_resumed",
+            f"resume-{attempt}",
+            {
+                "executor_id": "executor-kernel",
+                "attempt": attempt,
+                "feedback_sha256": feedback_sha256,
+            },
+        )
+    worktree = campaign / "executor/worktree"
+    worktree.mkdir(parents=True)
+    handle = ExecutorHandle(
+        executor_id="executor-kernel",
+        campaign_id="campaign-1",
+        technique="kernel",
+        root=worktree.parent,
+        worktree=worktree,
+        prompt=worktree.parent / "goal.md",
+        delivery=worktree / "DELIVERY.json",
+        receipt=worktree.parent / "process-003.json",
+        pid=123,
+        attempt=3,
+        lease_resource="executor:campaign-1:kernel",
+        lease_owner="agent:executor-kernel",
+    )
+    hooks = object.__new__(FileCampaignHooks)
+    hooks.campaign_dir = campaign
+    hooks.campaign_id = "campaign-1"
+    hooks.store = store
+    hooks.registry = TechniqueRegistry.load(
+        Path(__file__).resolve().parents[1] / "techniques/registry.toml"
+    )
+    hooks._ensure_next_executor = lambda epoch: "cache"  # type: ignore[method-assign]
+    try:
+        result = hooks._resume_or_exhaust(handle, feedback, epoch=1)
+        assert result.payload["reason"] == "executor_lane_deferred"
+        assert result.payload["next_technique"] == "cache"
+        deferred = json.loads((search / "DEFERRED-LANES.json").read_text())
+        assert deferred["lanes"]["kernel"]["attempt"] == 3
+        manifest = json.loads((search / "EXECUTORS.json").read_text())
+        assert manifest["active_technique"] is None
     finally:
         store.close()

--- a/sgl-engine-sglang-diffusion/tests/test_sources.py
+++ b/sgl-engine-sglang-diffusion/tests/test_sources.py
@@ -106,3 +106,61 @@ def test_old_lock_remains_materializable_after_a_new_lock(
     assert run(["git", "rev-parse", "HEAD"], cwd=old_worktree).stdout.strip() == (
         old_lock.commit
     )
+
+
+def test_create_worktree_materializes_required_pinned_submodule(
+    fake_git_repo: Path, tmp_path: Path
+) -> None:
+    submodule = tmp_path / "kernel-wiki"
+    submodule.mkdir()
+    run(["git", "init", "-b", "main"], cwd=submodule)
+    run(["git", "config", "user.name", "Test"], cwd=submodule)
+    run(["git", "config", "user.email", "test@example.com"], cwd=submodule)
+    (submodule / "SKILL.md").write_text("# KernelWiki\n")
+    run(["git", "add", "SKILL.md"], cwd=submodule)
+    run(["git", "commit", "-m", "knowledge"], cwd=submodule)
+    expected = run(["git", "rev-parse", "HEAD"], cwd=submodule).stdout.strip()
+
+    run(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(submodule),
+            "external/KernelWiki",
+        ],
+        cwd=fake_git_repo,
+    )
+    run(["git", "commit", "-am", "pin knowledge"], cwd=fake_git_repo)
+
+    manager = SourceManager(tmp_path / "sources")
+    lock = manager.lock("kda_pilot", str(fake_git_repo), "main")
+    worktree = manager.create_worktree(
+        lock,
+        tmp_path / "candidate",
+        initialize_submodules=True,
+        required_submodules=("external/KernelWiki",),
+    )
+
+    assert (worktree / "external/KernelWiki/SKILL.md").is_file()
+    actual = run(
+        ["git", "rev-parse", "HEAD"], cwd=worktree / "external/KernelWiki"
+    ).stdout.strip()
+    assert actual == expected
+
+
+def test_required_submodule_must_be_a_pinned_gitlink(
+    fake_git_repo: Path, tmp_path: Path
+) -> None:
+    manager = SourceManager(tmp_path / "sources")
+    lock = manager.lock("kda_pilot", str(fake_git_repo), "main")
+
+    with pytest.raises(RuntimeError, match="required submodule"):
+        manager.create_worktree(
+            lock,
+            tmp_path / "candidate",
+            initialize_submodules=True,
+            required_submodules=("external/KernelWiki",),
+        )

--- a/sgl-engine-sglang-diffusion/tests/test_verifier.py
+++ b/sgl-engine-sglang-diffusion/tests/test_verifier.py
@@ -51,6 +51,11 @@ class ForbiddenQualityEvaluator:
         raise AssertionError("lossless verification invoked a quality evaluator")
 
 
+class ForbiddenMethodAuditor:
+    def audit(self, **_: Any) -> bool:
+        raise AssertionError("static preflight invoked a method auditor")
+
+
 @pytest.fixture
 def registry() -> TechniqueRegistry:
     root = Path(__file__).parents[1]
@@ -376,7 +381,27 @@ def test_valid_lossless_never_calls_quality_evaluator(
     assert result.verified_points[0].authoritative_speedup == 2.0
     assert result.verified_points[0].activation == {"enable_agent_kernel": True}
     assert result.verified_points[0].source_hashes == evidence["source_hashes"]
+    assert len(result.authenticated_measurements) == 1
     assert auditor.calls == 1
+
+
+def test_static_preflight_reuses_verifier_without_independent_auditor(
+    evidence: dict[str, Any], registry: TechniqueRegistry
+) -> None:
+    verifier = make_verifier(
+        evidence,
+        registry,
+        auditor=ForbiddenMethodAuditor(),  # type: ignore[arg-type]
+    )
+
+    result = verifier.verify(
+        evidence["delivery_path"],
+        technique="kernel",
+        executor_worktree=evidence["worktree"],
+        independent_gates=False,
+    )
+
+    assert result.accepted, result.findings
 
 
 def test_launched_campaign_rejects_candidate_command_drift(
@@ -462,6 +487,7 @@ def test_launched_campaign_rejects_candidate_command_drift(
     assert "baseline_command_mismatch" in {
         finding.code for finding in rejected.findings
     }
+    assert rejected.authenticated_measurements == ()
 
 
 def test_resolve_inside_and_verifier_reject_path_escape(
@@ -593,6 +619,8 @@ def test_kernel_delivery_requires_all_three_kda_evidence_paths(
     )
     assert not result.accepted
     assert "invalid_kernel_evidence" in {finding.code for finding in result.findings}
+    assert len(result.authenticated_measurements) == 1
+    assert result.authenticated_measurements[0].candidate_mean_e2e_s == 5.0
 
 
 def test_implemented_kernel_requires_before_after_ncu_reports(

--- a/skills/sglang-diffusion-auto-optimize/SKILL.md
+++ b/skills/sglang-diffusion-auto-optimize/SKILL.md
@@ -60,6 +60,11 @@ not replace immutable inputs with memory. Warp timeline instrumentation is
 conditional on an actually warp-specialized CUDA/CuTe candidate, but the
 applicability audit is always required.
 
+The KDA-Pilot checkout is incomplete until its pinned KernelWiki, NCU, and
+warp-specialization gitlinks are initialized and verified. Do not start search
+from an empty or partially reused knowledge snapshot. The controller validates
+the copied references and their hashes before spawning a kernel Executor.
+
 ## Phase 1: Resolve The Remote Environment
 
 Connect using the matching host skill. Determine:
@@ -154,6 +159,12 @@ output, scheduler/exact precomputation/synchronization, communication layout
 under the frozen topology, and custom/upstream kernels. Precision changes and
 approximate reuse stay in quality-gated lanes.
 
+For a quality-gated target of at least 3x, use the controller's large-gap route:
+`residency`, then `cache`, `pisa`, `quantization`, `token_pruning`, and finally
+the remaining `kernel` tail. For smaller or lossless-only targets, keep
+lossless-first routing. Every required lane remains in the route; ordering only
+prevents a low-impact lane from blocking methods capable of closing the gap.
+
 The launcher rejects shell pipelines, redirects, substitutions, ambiguous
 duplicate workload flags, and baseline/model mismatch. Do not work around those
 failures by weakening validation. Convert a safe command into explicit
@@ -211,12 +222,26 @@ headroom, peak-memory delta, and H2D count/time delta. Do not report “high VRA
 as a result by itself.
 
 The detached controller launches and resumes Executor/Master agents itself.
+For `codex exec`, it persists the exact `thread.started` ID and resumes with
+`codex exec resume <thread-id>`; it never uses `--last` and never rebuilds a
+fresh conversation from the full prompt. Each Executor receives a
+controller-generated `DELIVERY-CONTRACT.json` and must pass its static
+preflight command before returning. Static preflight cannot self-approve the
+independent method or quality gate.
+
 Only one GPU-capable Executor is active at a time. A scientific round means one
 authenticated complete frozen-workload candidate measurement—not a process
-launch, retry, microbenchmark, malformed delivery, or infrastructure failure.
+launch, retry, microbenchmark, pre-measurement malformed delivery, or
+infrastructure failure. If the complete measurement is authentic but a later
+evidence field is malformed, the measurement consumes one idempotent round.
 A rejected hypothesis feeds the same lane; it does not close the lane or the
 campaign. Retain every independently verified positive candidate for combined
 remeasurement.
+
+The same verifier signature may be resumed at most three times and one
+Executor generation at most six times. After that, defer the lane for the
+current epoch and continue other routes. A deferral is not search exhaustion;
+if no productive route remains, report the exact infrastructure block.
 
 Never add technique speedups together. `marginal_attribution: not_measured`
 means no leave-one-out measurement exists.

--- a/skills/sglang-diffusion-auto-optimize/references/progress-contract.md
+++ b/skills/sglang-diffusion-auto-optimize/references/progress-contract.md
@@ -31,10 +31,13 @@ fields in new campaign artifacts.
 
 Search progress is consumed routed-technique rounds divided by their total
 reviewed round budgets. It measures budget consumption, not time remaining.
-A round is counted only after the controller authenticates a distinct complete
+A round is counted after the controller authenticates a distinct complete
 frozen-workload candidate measurement. Agent launches/resumes, crashes,
-preflight, profile capture, NCU/microbenchmarks, malformed submissions, and
-unmeasured hypotheses consume no scientific round.
+preflight, profile capture, NCU/microbenchmarks, pre-measurement malformed
+submissions, and unmeasured hypotheses consume no scientific round. If a full
+measurement passes the frozen command/native backend/5-request checks but a
+later evidence or audit field is malformed, that measurement consumes one
+round. Resubmitting the same run is idempotent.
 
 ## Technique Rows
 
@@ -46,7 +49,10 @@ unmeasured hypotheses consume no scientific round.
 
 Never sum isolated speedups.
 
-The default lossless search begins with `residency`, then `kernel`. Multi-GPU
+The lossless-only search begins with `residency`, then `kernel`. A quality-gated
+target of at least 3x uses `residency`, `cache`, `pisa`, `quantization`,
+`token_pruning`, then `kernel` so high-leverage methods are not blocked by a
+marginal kernel tail. Multi-GPU
 does not automatically add a topology-changing lane: GPU UUIDs, rank map, and
 parallel degrees are frozen by the user baseline. Collective and layout
 implementations may still be optimized under that frozen topology.


### PR DESCRIPTION
## Summary

Repair the SGLang Diffusion autonomous optimization loop so protocol failures no longer hide real GPU progress or restart a fresh Codex agent on every verifier retry.

The reported entry point was `sglang-humanize-review`, but the stalled optimization state machine is owned by the sibling `sglang-diffusion-auto-optimize` skill and `sgl-engine-sglang-diffusion` controller, so the behavioral fixes live there.

## Root causes addressed

- KDA-Pilot worktrees skipped their pinned KernelWiki, NCU, and warp-specialization submodules, producing incomplete reusable knowledge snapshots.
- Executor output depended on prose-only schemas and guessed citation paths; malformed evidence caused repeated retries.
- “Resume” relaunched `codex exec` with replayed prompt history instead of resuming the original Codex thread.
- Complete frozen-workload measurements were not counted when a later evidence field failed, allowing expensive runs to repeat without visible progress.
- One broken lane could retry indefinitely and prevent high-leverage quality-gated lanes from running.
- Large targets still followed a low-leverage lossless-first tail.
- Minimal containers lacked writable Codex mode and process-local Git identities; H3 workload freezing and integration commits were incomplete.

## What changes

- Initialize and verify exact KDA gitlinks; build knowledge snapshots transactionally and revalidate all copied digests on reuse.
- Generate a controller-owned `DELIVERY-CONTRACT.json` with current Pydantic schemas, frozen baseline/profile/command/GPU bindings, required artifacts, and exact pinned KernelWiki citations.
- Add `preflight-delivery`, using the same structural verifier while retaining independent method/quality approval in the controller.
- Persist the exact `thread.started` ID and invoke `codex exec resume <thread-id>` with a compact feedback turn; never use `--last`.
- Count authenticated full-workload measurements idempotently even when later evidence/audit validation rejects the delivery.
- Defer a lane after the third identical verifier failure or sixth process attempt and continue other routes; deferred is distinct from exhausted.
- Route quality-gated targets >=3x through residency, cache, PISA, quantization, and token pruning before the kernel tail.
- Report only the manifest's active lane as running.
- Preserve the already-proven H3 workload, writable Executor, and local Git identity fixes.

Existing non-Codex agents retain full prompt replay. Authoritative verification remains fail-closed; the static preflight cannot self-approve an independent gate.

## Validation

- `pytest -q` — 172 passed
- `python3 -m ruff check src tests` — passed
- `quick_validate.py skills/sglang-diffusion-auto-optimize` — Skill is valid
- `python3 -m pip wheel . --no-deps --no-build-isolation` — wheel built successfully
