### PR TITLE
Simplify SGLang diffusion optimization flows

### DIFF
--- a/sglang-diffusion-optimization-flows/components/vae-audio.md
+++ b/sglang-diffusion-optimization-flows/components/vae-audio.md
@@ -14,14 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 从真实 pipeline 保存进入 audio decoder 的 latent，并固定 sample rate、duration、channels、mel bins/hop、dtype 和 chunk/window，建立 eager waveform reference。比较 waveform cosine、normalized MSE、sample count、采样率、声道、峰值、响度、频谱以及 A/V duration/sync；覆盖静音、短音频、非整 chunk 和连续请求。
+2. 测试固定音频重建数据集上的精度，建立优化前的精度基线。
 
-3. 分析选中实现的架构，拆分 audio VAE、vocoder、mel preprocess、Conv1d/transpose conv、norm/activation、overlap-add、resample、layout、CPU I/O 和 mux；记录真实 tensor shape、padding/causal 语义、调用次数与 codec contract，不跨实现复用数值结论。
+3. 分析 decoder 架构。
 
-4. 对 isolate harness 和完整 E2E 分别 profile eager 与 torch.compile，按组件和 kernel 汇总耗时，定位 Conv1d、transpose conv、norm、activation、overlap-add、layout conversion、resample、mux、CPU sync 和 graph break；H3 保持 eager 为唯一 lossless reference。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 audio shape 调研 PyTorch、TorchAudio、TorchCodec、Diffusers、SGLang、cuDNN 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 implementation/sample-rate/window/dtype/shape/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、重复 resample/cast/permute、mel/window materialize、overlap-add 临时张量和 mux 前 copy；重点检查 conv+bias+activation、norm+activation、vocoder、resample 批量化和 layout 消除，保持 padding/causal 语义。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 latent 和联合音视频样本验收 component、waveform 和 E2E。audio cosine 至少 0.999、normalized MSE 不超过 1e-4，sample rate/channels/sample count/duration/A-V sync 完全符合合同；20 次 warmup、100 次计时和 1000 次 soak 均稳定且组件/E2E 收益超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
@@ -14,14 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 从对应 native pipeline 保存进入 decoder 的真实 latent，并在 ImageNet-val 或固定重建集上建立 eager reference。分别记录 untiled 和生产 tiled shape 的 output cosine、normalized MSE、PSNR、SSIM、LPIPS、颜色及 tile seam；FLUX.1、Z-Image、SD3、GLM 的 config/latent scaling 各自验收。
+2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKL 架构，拆分 decoder conv、resblock、GroupNorm、SiLU、mid-block attention、upsample、tiling、blend 和 postprocess；记录 channels、scaling/shift、stride、padding、tile/overlap、dtype、layout 与调用次数，GLM 额外记录 latent mean/std。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 decode-only harness，20 次 warmup、100 次计时，并 profile torch.compile 后各组件与 kernel 耗时；定位 conv、norm/activation、mid attention、upsample、tile blend、layout copy、graph break 和 launch overhead，同时保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 decoder shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断优化空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 model/config/dtype/channels/stride/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、reshape/shuffle、tile materialize 和重复 layout；重点证明 nearest 2x upsample+3x3 Conv 到等价 ConvTranspose2d、GroupNorm+SiLU、bias/residual、attention output projection 与 tile overlap/blend 的融合条件。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用未参与开发的 ImageNet-val/重建样本和固定 seed E2E 独立验收。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无颜色偏移和 tile seam；组件与 E2E 收益超过方差才接受，否则回到第 4 步继续优化。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
+++ b/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model sana-1.5-1.6b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 保存 512px 和 1024px 的真实 latent，在 ImageNet-val 或固定重建集上建立 eager reference。记录 output cosine、normalized MSE、PSNR、SSIM、LPIPS，并重点检查 32x compression 下的细线、文字、小物体、颜色和 tile seam；600M、1.6B、4.8B 的代表 config 分别验收。
+2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderDC wrapper 与 Diffusers inner model，拆分 encode/decode、conv、channel mixing、norm/activation、upsample、tiling 和 postprocess；记录真实 channels、stride、compression ratio、tile、dtype、layout 和 wrapper copy。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 decode-only harness，profile torch.compile 后 wrapper、inner model、各层和 kernel 耗时，定位 conv、channel mixing、upsample、layout conversion、tile blend、graph break 和 launch overhead；20 次 warmup、100 次计时并保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 DC-AE shape 调研 Diffusers、PyTorch/cuDNN、SGLang、CUTLASS/Triton 已有实现，并用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 config/dtype/channels/stride/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、wrapper copy、reshape/shuffle、layout 转换和 tile 临时张量；重点检查 channel mixing、norm+activation、residual、upsample+conv 和 tile overlap/blend，不能假设与其他 VAE 的 tiling 语义相同。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 ImageNet-val/重建样本和 SANA 600M/1.6B E2E 验收精度、速度和显存。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且细节/颜色无回归；组件和 E2E 都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-flux2.md
+++ b/sglang-diffusion-optimization-flows/components/vae-flux2.md
@@ -14,14 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 从 FLUX.2、Ideogram 4 和 ERNIE-Image 各保存一个真实 latent shape，在固定重建集上分别建立 eager reference。记录 output cosine、normalized MSE、PSNR、SSIM、LPIPS、颜色和 tile seam；FP8/NVFP4 checkpoint 也记录 VAE 的实际 dtype，不能跨 config 复用数值结论。
+2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKLFlux2 架构，拆分 encode/decode、batch norm、resblock、attention、upsample、parallel tiling、tile blend 和 postprocess；记录每个 config 的 latent/patch、channels、stride、tile、dtype、layout 与调用次数。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 decode-only harness，profile torch.compile 后各组件与 kernel 耗时，定位 batch norm、conv、attention、resblock、upsample、tile blend、layout conversion、graph break 和 launch overhead；20 次 warmup、100 次计时并保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill分析优化空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 model/config/dtype/channels/stride/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、reshape/shuffle、layout 转换和 tile 临时张量；重点检查 batch norm/activation、residual、upsample+conv、attention output projection 与 tile overlap/blend，一次只合入一个可归因改动。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 使用独立重建样本和 FLUX.2、Ideogram、ERNIE 固定 seed E2E 验收。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/色偏；组件与三种 config 的 E2E 收益都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 保存生产分辨率和帧数的真实 latent，在固定视频重建集上建立 eager reference。记录 latent/output cosine、normalized MSE、逐帧 PSNR/SSIM、最差帧、首尾、seam 和 flicker；HunyuanVideo 与 FastHunyuan 分别验收，少步数质量变化不能归因给 VAE。
+2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKLHunyuanVideo 架构，拆分 decoder conv、resblock、attention、upsampler GroupNorm+SiLU、temporal/spatial tiling、tile blend 与 decode postprocess；记录 channels、stride、padding、tile/overlap、dtype、layout、调用次数和 causal 边界。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 decode-only harness，profile torch.compile 后各组件与 kernel 耗时，先确认已有 Hunyuan/LTX upsampler fusion 是否命中，再定位 conv、resblock、attention、GroupNorm+SiLU、upsample、tile blend、layout copy 和 graph break；20 次 warmup、100 次计时。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实视频 shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill确认优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 dtype/channels/frames/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、reshape/shuffle、temporal/spatial layout 转换和 tile 临时张量；重点检查 GroupNorm+SiLU、residual、upsample+conv、attention output projection 与 tile overlap/blend，保持边界和时间语义。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 latent、视频和 FastHunyuan E2E 验收精度、速度与峰值显存。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker；component 与 E2E 均稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 保存真实 point、latent、ShapeVAE 输出和 mesh reference，固定输入图、seed、point 数、dtype 和 topology。比较 latent cosine/MSE、顶点/面数量、有限值、包围盒、抽样 Chamfer、mesh 可加载性和拓扑；不能用图像 PSNR 代替 shape correctness。
+2. 测试固定 shape 重建数据集上的精度，建立优化前的精度基线。
 
-3. 分析 ShapeVAE 架构，拆分 point/latent packing、attention、GEMM、norm、projection、scatter/gather、decode、surface extraction 与 mesh export；记录真实 point count、hidden shape、dtype、padding、index layout、空 tensor 和 CPU/GPU 边界。
+3. 分析 decoder 架构。
 
-4. 用保存的 point/latent 建 component harness，profile torch.compile 后 ShapeVAE 各层与 kernel 耗时，并将 surface/mesh 后处理单独归因；定位 attention、GEMM、scatter/gather、index materialize、layout copy、CPU sync 和 graph break，20 次 warmup、100 次计时。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 point/latent shape 调研 PyTorch、SGLang、Kaolin、PyTorch3D、CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断优化空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 point-count/index/dtype/shape/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、重复 scatter/gather、reshape/shuffle、index materialize 和 CPU/GPU 往返；重点检查 projection、norm/activation、residual、point packing 与可批量的 surface postprocess，不改变 mesh topology。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入图、point cloud 和 mesh 样本验收精度、速度、显存与输出可用性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，顶点/面、包围盒和 Chamfer 在预设容差内且无拓扑破损；ShapeVAE stage 与完整 mesh E2E 均超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-ti2v-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 从 LTX-2.3 two-stage、SANA-WM streaming 和 JoyAI-Echo 各保存真实 latent，在固定视频重建集上分别建立 eager reference。记录 cosine、normalized MSE、逐帧 PSNR/SSIM、最差帧、chunk/tile seam、时间漂移、历史状态和长视频显存；不同 config 不共享数值结论。
+2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKLLTX2Video 与 causal entry class，拆分 causal Conv3d、resblock、attention、upsampler GroupNorm+SiLU、tile/stream overlap、history state、blend 和 decode postprocess；记录 channels、frames、stride、padding、dtype、layout、tile 与调用次数。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 decode-only 和 streaming harness，profile torch.compile 后各组件与 kernel 耗时，先确认已有 upsampler fusion、tiling 和 parallel decode 是否命中，再定位 causal Conv3d、norm/activation、attention、upsample、tile blend、state copy 和 graph break；20 次 warmup、100 次计时。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实视频 shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 causal/history/config/dtype/frames/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、reshape/shuffle、history/cache materialize、temporal/spatial layout 转换和 tile 临时张量；重点检查 causal Conv3d、GroupNorm+SiLU、residual、upsample+conv 与 tile/stream overlap blend。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 latent 和 LTX/SANA-WM/JoyAI-Echo E2E 验收精度、速度、显存与 streaming 状态。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/时间漂移；所有 config 稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
@@ -14,14 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 用 H3 eager T2VA 保存最终 video latent，并从 FL2VA/Ref2VA 保存 encode 输入，建立唯一 lossless reference；当前 torch.compile 结果不能充当 reference。固定 1344x768、124 帧、24 fps、tile/overlap、BF16、TP2+Ulysses2，比较 component cosine/MSE、逐帧 PSNR/SSIM、最差帧、seam、flicker、帧数和时间戳。
+2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 MiniMaxH3VideoVAE 架构，拆分 encode、默认 overlapping tiled decode、conv、resblock、attention、norm/activation、upsample、tile blend 和 postprocess，并从 MiniMaxH3VAEDecodingStage 中剥离 audio VAE 与 mux。记录 channels、frames、stride、padding、dtype、layout 和 tile recipe；released contract 禁止 spatial、spatial-shard 和 patch decode。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 VAE-only harness，先 profile eager，再用相同输入单独 profile torch.compile 候选，按组件和 kernel 定位 causal/spatial conv、resblock、attention、norm/activation、upsample、tile overlap/blend、layout copy 和 graph break；compile 数值变化单独记录，20 次 warmup、100 次计时。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 H3 VAE shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention 和 CUTLASS/Triton 已有实现，用 ncu-report skill判断 memory、compute、occupancy 或 launch bound。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 H3 config/dtype/channels/frames/tile/device guard、exact test 和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 eager/compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、reshape/shuffle、temporal/spatial layout 转换、tile materialize 和 overlap 重复计算；重点证明 norm+activation、bias/residual、upsample+conv、attention output projection 和 tile blend 的等价条件。不得为了速度绕过 released tile contract。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 T2VA、FL2VA、Ref2VA latent 和联合音视频 E2E 验收。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，无 seam/flicker且 A/V sync 不变；组件和 E2E 收益超过方差才接受，否则回到第 4 步继续执行第 5、6 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 保存 T2I、Edit 和 Layered 的真实 encode/decode latent，在固定图像重建集上建立 eager reference。记录 component cosine、normalized MSE、PSNR、SSIM、LPIPS 和 tile seam；Qwen、Krea-2、FireRed 的 config、latent scaling 和输入层数分别验收，100 次 edit soak 检查缓存污染。
+2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKLQwenImage 架构，拆分 causal Conv3d、resblock、attention、norm/activation、upsample、tiling/parallel decode、tile blend 与 postprocess；记录 temporal length、channels、stride、padding、dtype、layout、tile 和 feature cache 语义。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 encode/decode harness，profile torch.compile 后各组件与 kernel 耗时，定位 causal Conv3d、resblock、attention、GroupNorm/SiLU、upsample、tile blend、layout conversion、cache copy 和 graph break；20 次 warmup、100 次计时并保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 image/edit/layered shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 temporal/cache/layer/config/dtype/tile/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、reshape/shuffle、temporal layout 转换、cache/tile materialize；仅在 T=1 且无历史 cache 时证明 causal Conv3d 到 Conv2d 等价，并检查 norm+activation、residual、upsample+conv、attention projection 和 tile blend。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 Qwen、Krea-2、FireRed 和 Layered latent/E2E 验收。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 tile seam/cache 污染；所有 config 的组件与 E2E 都稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
+++ b/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
@@ -14,14 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 从真实 pipeline 保存 latent，并在 ImageNet-val 或对应视频/音频/shape 重建集上建立 eager reference。记录 component cosine、normalized MSE、PSNR、SSIM、LPIPS 或领域指标；固定 checkpoint、shape、dtype、tile/cache、seed 和 topology，不要求 bit-identical，但先定义合理容差。
+2. 测试对应重建数据集上的精度，建立优化前的精度基线。
 
-3. 分析 decoder 架构并为每个候选写等价式和适用前提：nearest 2x upsample+3x3 Conv 到 ConvTranspose2d、causal Conv3d 单帧到 Conv2d、attention output projection 折叠进 value projection、bias/residual 到 GroupNorm statistics，以及 attention head_dim 盲区。记录 dtype/layout/device/shape/cache/train guard 和可回滚的原路径。
+3. 分析 decoder 架构。
 
-4. profile torch.compile 后各组件和 kernel 耗时，确认候选位于真实热点且收益上限值得实现；用 decode-only harness 做 20 次 warmup、100 次计时，记录 global memory traffic、launch、layout、tile overlap、graph break 和 E2E 占比。torch.compile 已经完成的优化不重复包装。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）对关键 shape 调研 PyTorch、Diffusers、SGLang、cuDNN、FlashInfer、FlashAttention、CUTLASS/Triton 的现有实现，并用 ncu-report skill证明剩余空间。需要新 kernel 时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带完整 guard、幂等安装、restore/rollback、测试和 fallback 的实现。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）优先实现数学等价且能移除大中间张量的 rewrite，再研究 kernel 内 fuse；重点减少 global memory 读写、reshape/shuffle、layout conversion、tile materialize 和重复统计。离线合成权重使用 FP32，并记录 checkpoint/source/shape/dtype/topology 指纹；一次只提交一个候选。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 使用未参与开发的重建样本独立验收精度、组件速度、E2E 和 1000-call soak。component cosine 至少 0.999、normalized MSE 不超过 1e-4，图像/视频 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且边界/缓存语义正确；收益或精度不达标就拒绝候选并回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
@@ -13,14 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model wan-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 保存 Wan 720p decode、I2V encode+decode 和 Cosmos3 z_dim=48 的真实 latent，在固定视频重建集上分别建立 eager reference。记录 cosine、normalized MSE、逐帧 PSNR/SSIM、最差帧、首尾、seam、flicker 和 cache；Wan、Cosmos3、Helios、JoyAI、MOVA、LingBot、LongLive 的代表 config 分别验收。
+2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
 
-3. 分析 AutoencoderKLWan 架构，拆分 causal Conv3d、resblock、RMS/GroupNorm、attention、upsample、temporal/spatial/patch tiling、跨 rank gather/blend 和 postprocess；记录 z_dim、channels、frames、stride、padding、dtype、layout、tile、cache 与合法 parallel decode 模式。
+3. 分析 decoder 架构。
 
-4. 用保存的 latent 建 encode/decode harness，profile torch.compile 后各组件与 kernel 耗时，定位 causal Conv3d、norm、resblock、attention、upsample、tile overlap/blend、layout copy、跨 rank gather 和 graph break；分别测 full/spatial/temporal/patch 合法模式，20 次 warmup、100 次计时。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实视频 shape 调研 SGLang、Diffusers、PyTorch/cuDNN、FlashAttention、CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 model/z_dim/causal/cache/dtype/tile/topology/device guard、测试和 fallback 的 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。
 
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、reshape/shuffle、temporal/spatial layout 转换、跨 rank materialize 和 tile 重叠计算；仅在严格 T=1 且无 cache 时证明 Conv3d 到 Conv2d 等价，并检查 norm+activation、residual、upsample+conv 和 tile blend。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立 Wan、Cosmos3 和其他目标 config 的 latent/E2E 验收精度、速度、显存和 parallel decode。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker；所有 guard/fallback 和代表 config 都通过才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/cosmos3.md
+++ b/sglang-diffusion-optimization-flows/models/cosmos3.md
@@ -16,21 +16,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model cosmos3-super-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、分辨率、帧数、fps、steps、dtype 和 GPU topology 保存 eager reference。T2I 使用固定图像集比较 PSNR、SSIM、LPIPS；T2V/I2V 使用固定视频集比较逐帧 PSNR/SSIM、最差帧、闪烁和首尾帧；实际命中 AVAE 时再检查 waveform、采样率和音视频同步。隔离 benchmark 可关闭 guardrail，但生产验收必须打开。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Cosmos3 native pipeline 架构，拆分文本/图像 encoder、DiT、scheduler、Wan-style z_dim=48 video VAE、可选 AVAE、guardrail 和 postprocess，分别记录 Nano/Super 以及 T2I/T2V/I2V 的 tensor shape、dtype、调用次数和并行方式。
+3. 分析模型架构。
 
-4. 在相同输入上 profile torch.compile 后的完整 E2E 和所有 stage，按组件及 kernel 汇总耗时，重点定位 attention、MLP、modulation、A2A、causal Conv3d、tile blend、audio decode 与 mux；同时保留 eager trace，确认 compile 没有隐藏 graph break 或 fallback。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model cosmos3-super-t2v --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch、CUTLASS/Triton 中是否已有高性能 kernel；用 ncu-report skill 采集 NCU 证据判断 memory、compute、occupancy 或 launch bound。没有合适实现时启动 kernel design sub agent，使用 ultra 模式并结合 KernelWiki 和 ncu-report skill 开发带完整 dtype/shape/device guard 与 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 torch.compile 后仍未解决的等价 fuse，优先减少 global memory 读写、layout 转换、reshape、shuffle、cat/permute 和跨 rank materialize；重点验证 modulation、norm/activation、residual、upsample+conv、causal Conv3d 单帧退化、tile overlap/blend 是否能数学等价重写。一次只合入一个可归因改动。
-
-7. 用未参与开发的固定输入独立验收精度、速度、峰值显存和多卡 scaling。图像 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，视频还必须无 seam/flicker，component cosine 至少 0.999、normalized MSE 不超过 1e-4；20 次 warmup、100 次计时且组件和 E2E 收益都超过运行方差才接受，否则回到第 4 步继续执行第 5、6 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ernie-image.md
+++ b/sglang-diffusion-optimization-flows/models/ernie-image.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ernie-image-turbo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、1024px 分辨率、steps、guidance、dtype 和 GPU topology，保存 eager 输出与进入 VAE decoder 的 latent。使用固定图像重建集比较 PSNR、SSIM、LPIPS、颜色和文字细节；Turbo 与 Base 分开建立质量和性能 reference。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 ERNIE-Image native pipeline，拆分 condition encoder、DiT attention/MLP/modulation、scheduler、AutoencoderKLFlux2 encode/decode 和 postprocess；记录 latent scaling、patch/config、batch norm、tile 参数和各阶段真实 shape。
+3. 分析模型架构。
 
-4. profile torch.compile 后的完整 E2E、denoise 和 VAE stage，按组件及 kernel 汇总耗时，定位 joint attention、GEMM、norm、RoPE、batch norm、resblock、upsample、tile blend、layout copy 与 graph break；保留相同输入的 eager trace用于对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model ernie-image-turbo --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对 profile 的关键 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch、CUTLASS/Triton 已有实现，并用 ncu-report skill 分析瓶颈。已有 kernel 不够快时启动 kernel design sub agent，使用 ultra 模式和 KernelWiki、ncu-report skill 开发专用 kernel，保留 dtype、channels、stride、tile 和设备 guard 以及原实现 fallback。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先消除 global memory 往返、reshape/shuffle、permute/cat 和重复标准化；重点检查 modulation、norm+activation、residual、upsample+conv、tile overlap/blend 与 latent scaling 的融合。量化、少步数和 cache 路线单独记为近似优化。
-
-7. 使用独立 prompt 与重建样本复验 Turbo 和 Base 的精度、速度与显存。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002；20 次 warmup、100 次计时并确认 native backend 无 fallback，收益超过方差才接受，否则回到第 4 步继续优化。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/flux.md
+++ b/sglang-diffusion-optimization-flows/models/flux.md
@@ -17,21 +17,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2-klein --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、分辨率、steps、guidance、dtype 和 GPU topology，保存 eager 图像、DiT 输出和 VAE latent。用固定照片、文字和高频纹理样本比较 PSNR、SSIM、LPIPS；FLUX.1、FLUX.2、Klein 4B/9B/Base 以及 FP8/NVFP4 路线各自建立 reference，不能混表。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析每个 checkpoint 的 native pipeline，拆分 T5/CLIP encoder、double/single transformer blocks、joint attention、modulation、RoPE、MLP、scheduler 和 VAE。FLUX.1 使用 AutoencoderKL 2D；FLUX.2/Klein 使用 AutoencoderKLFlux2，逐个记录 latent channels、scaling、tile 和真实 attention shape。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件及 kernel 耗时，重点定位 joint attention、packed QKV、head_dim、GEMM、Nunchaku GELU MLP、modulation、RoPE、VAE norm/resblock/upsample、tile blend 和多卡通信；用相同输入保留 eager trace确认 graph break 与 fallback。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model flux2 --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对关键 shape 调研 SGLang、Nunchaku、FlashInfer、FlashAttention、Diffusers、PyTorch、CUTLASS/Triton 的现有 fast path，再用 ncu-report skill 判断优化空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill 开发带完整 guard、测试和 fallback 的 attention、MLP 或 VAE kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍存在的 fuse 机会，优先减少 global memory 读写、reshape、shuffle、permute、cat 和无效 materialize；重点检查 QKV/RoPE/norm、scale-shift-gate、residual、GELU MLP、upsample+conv、norm+activation 与 tile blend 的数学等价融合。NVFP4/FP8 属于单独质量预算。
-
-7. 用独立 prompt 和 latent 验收每个目标 checkpoint 的精度、速度、峰值显存和多卡 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，图像 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002；20 次 warmup、100 次计时且组件与 E2E 都稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/glm-image.md
+++ b/sglang-diffusion-optimization-flows/models/glm-image.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model glm-image --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 1024px prompt、seed、steps、guidance、dtype 和 GPU topology，保存 eager 输出、标准化前后 latent 与 VAE 输入。用固定 ImageNet-val 子集或等价重建集比较 PSNR、SSIM、LPIPS和色偏，并记录固定 seed E2E 感知结果。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 GLM-Image pipeline，拆分 GLM condition encoder、DiT attention/MLP/modulation、scheduler、latent mean/std 标准化、AutoencoderKL 2D encode/decode、spatial parallel decode 和 postprocess，记录每个阶段真实 shape、dtype、tile 与并行合同。
+3. 分析模型架构。
 
-4. profile torch.compile 后的完整 E2E 和所有 stage，定位 encoder、attention、GEMM、norm、标准化 broadcast、decoder conv/resblock、mid-block attention、upsample、tile blend、通信与 graph break；同输入保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model glm-image --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 的已有 kernel，并用 ncu-report skill 判断 compute、memory、occupancy 或 launch bound。必要时启动 kernel design sub agent，使用 ultra 模式与 KernelWiki、ncu-report skill 开发带标准化/config/device guard 和 fallback 的专用 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未完成的数学等价 fuse，优先减少 global memory 读写、reshape/shuffle、permute/cat 和重复 broadcast；重点检查 modulation、latent mean/std、norm+activation、residual、upsample+conv 与 tile blend。保持颜色范围和标准化语义不变。
-
-7. 用独立 prompt 和重建样本验收精度、速度、显存及 spatial parallel。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，并检查无色偏和 tile seam；20 次 warmup、100 次计时且无 fallback 才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/helios.md
+++ b/sglang-diffusion-optimization-flows/models/helios.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model helios --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、分辨率、帧数、fps、steps、dtype 和 topology，分别保存 Base/Mid/Distilled 的 eager reference。用固定视频集检查逐帧 PSNR/SSIM、最差帧、首尾、闪烁、运动连续性、cache reset 和长视频显存有界。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Helios native pipeline，拆分 condition encoder、专用 denoising stage、DiT attention/MLP/modulation、block cache/causal state、scheduler、Wan-style causal 3D VAE、postprocess 和多卡通信，记录各 variant 的真实 shape 与调用次数。
+3. 分析模型架构。
 
-4. profile torch.compile 后的完整 E2E 和所有 stage，重点定位 attention、GEMM、causal cache、A2A、causal Conv3d、resblock、upsample、tile overlap/blend、CPU 同步与 graph break；保留 eager trace比较首次和 steady-state latency。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model helios --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对关键 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有实现，使用 ncu-report skill 判断 kernel 或通信是否还有空间。需要新 kernel 时启动 kernel design sub agent，使用 ultra 模式和 KernelWiki、ncu-report skill实现严格 guard、cache 语义测试及 fallback。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍不理想的等价 fuse，优先减少 global memory 读写、reshape/shuffle、layout copy、cache materialize 和跨 rank gather；重点检查 modulation、norm/activation、residual、causal Conv3d、upsample+conv 与 tile blend，保持 chunk/cache 语义。
-
-7. 使用独立视频和长时 soak 验收 Base/Mid/Distilled 的精度、速度、显存和 cache 稳定性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker；20 次 warmup、100 次计时，收益超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/hunyuan.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan.md
@@ -14,21 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、分辨率、帧数、fps、steps、guidance、dtype 和 topology，分别保存原模型与 Fast 版本的 eager reference。使用固定视频集比较逐帧 PSNR/SSIM、最差帧、闪烁、运动和首尾一致性；蒸馏带来的质量变化不得归因给 lossless kernel。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native pipeline，拆分 dual text encoder、DiT attention/MLP/modulation、RoPE、scheduler、AutoencoderKLHunyuanVideo encode/decode、upsampler、tiling、postprocess 和通信，记录生产 shape、dtype与调用次数。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件与 kernel 耗时，重点定位 text encoder、长序列 attention、GEMM、A2A、decoder conv/resblock/attention、upsampler GroupNorm+SiLU、tile blend 和 graph break；保留 eager trace作为数值和性能对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 现有 kernel，再用 ncu-report skill确认优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发 attention、upsampler 或 VAE 专用 kernel，并保留严格 guard 和 fallback。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未解决的 fuse，优先减少 global memory 读写、reshape/shuffle、permute、tile materialize 和通信等待；重点验证 QKV/RoPE/norm、modulation、residual、GroupNorm+SiLU、upsample+conv 和 tile overlap/blend 的数学等价融合。
-
-7. 用独立 prompt、视频和 topology 验收原模型与 Fast 版本的精度、速度、显存和 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002并且无 seam/flicker；20 次 warmup、100 次计时且收益超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/hunyuan3d.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan3d.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定输入图、seed、point 数、steps、dtype 和 topology，保存 eager point/latent/mesh reference。检查 latent、顶点/面数量、有限值、包围盒、抽样 Chamfer、mesh 可加载性和明显拓扑破损；shape 稳定后再开启 paint，并对 paint 输出另做 PSNR/SSIM/LPIPS。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 pipeline 架构，拆分图像 condition encoder、shape DiT、ShapeVAE decode、surface extraction、mesh export、可选 paint 的 multiview UNet/AutoencoderKL 和 postprocess，记录各阶段 shape、dtype、CPU/GPU 边界和调用次数。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件与 kernel 耗时，分清 attention/GEMM/scatter、ShapeVAE 和 marching-cubes 类后处理，定位 layout、indexing、空 tensor、CPU sync、mesh export 和 graph break；保持相同 eager trace作为对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实点数和 latent shape 调研 SGLang、PyTorch、Diffusers、Kaolin、CUTLASS/Triton 中已有高性能实现，并用 ncu-report skill分析热点 kernel。需要新实现时启动 kernel design sub agent，使用 ultra 模式和 KernelWiki、ncu-report skill开发带 point-count、dtype、layout、device guard 与 fallback 的 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未处理好的等价 fuse，优先减少 global memory 读写、重复 gather/scatter、reshape/shuffle、index materialize 和 CPU/GPU 往返；重点检查 projection、norm/activation、residual、point packing 与 surface 后处理批量化。不得用改变网格拓扑的近似替换冒充 lossless fuse。
-
-7. 用独立输入图和 mesh 样本验收精度、速度、显存及输出可用性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，顶点/面、包围盒和 Chamfer 在预设容差内且无拓扑破损；20 次 warmup、100 次计时，shape stage 与完整 mesh E2E 都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ideogram4.md
+++ b/sglang-diffusion-optimization-flows/models/ideogram4.md
@@ -14,21 +14,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ideogram4-fp8 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定含小字号文字、复杂布局和普通照片的 prompt 集、seed、分辨率、steps、dtype 和 topology，保存 eager output 与 latent。比较 PSNR、SSIM、LPIPS、OCR 字符准确率、拼写、布局和人工 artifact；FP8/NF4、Fast/Instant 分别建立质量预算。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native pipeline，拆分长 prompt encoder、DiT joint attention/MLP/modulation、FlashAttention backend、scheduler、AutoencoderKLFlux2 batch norm/resblock/upsample/tile、postprocess 和多卡通信，记录真实 shape 与量化 dtype。
+3. 分析模型架构。
 
-4. profile torch.compile 后的完整 E2E 和所有 stage，按组件及 kernel 汇总耗时，重点定位长 prompt encoder、attention head shape、GEMM、modulation、batch norm、upsample、tile blend、A2A、dequant 和 graph break；保留 eager trace对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model ideogram4-fp8 --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有 kernel，并使用 ncu-report skill确认性能空间。必要时启动 kernel design sub agent，使用 ultra 模式和 KernelWiki、ncu-report skill开发带 dtype/quant/config/device guard、fallback 及文字样本测试的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未完成的等价 fuse，优先减少 global memory 读写、reshape/shuffle、permute/cat、dequant materialize 和 tile 临时张量；重点检查 QKV/RoPE/norm、modulation、residual、batch norm/activation、upsample+conv 与 tile blend。
-
-7. 用独立文字和照片 prompt 验收各 variant 的精度、速度、显存和多卡 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，OCR/拼写和布局不得超出既定质量预算；20 次 warmup、100 次计时且 E2E 稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/joyai-echo.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-echo.md
@@ -13,20 +13,14 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A curious raccoon" --width 640 --height 384 --num-frames 33 --num-inference-steps 8 --seed 42 --num-gpus 2 --ulysses-degree 2 --enable-memory-bank false --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 固定 prompt、seed、分辨率、帧数、fps、steps、audio window、memory-bank 参数、dtype 和 topology，保存 eager 视频与音频 reference。比较逐帧 PSNR/SSIM、最差帧、闪烁、waveform cosine/MSE、采样率、声道、duration 和 A/V sync；再做长视频 cache reset 与显存有界测试。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 pipeline，拆分 condition encoder、DiT、paired audio-video memory bank、96-window audio selection、mel preprocess、LTX-2.3 video VAE、LTX audio VAE/vocoder、scheduler、AV decode 和 mux，记录每个 stage 的 shape、dtype、调用次数和 cache key。
+3. 分析模型架构。
 
-4. 分别 profile torch.compile 开/关的完整 E2E 和各 stage，按 kernel 汇总 attention、GEMM、memory-bank copy、mel、Conv1d/Conv3d、resblock、upsampler、vocoder、resample 和 mux；重点观察首次与 steady-state latency、graph break 和 CPU sync。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A curious raccoon" --width 640 --height 384 --num-frames 33 --num-inference-steps 8 --seed 42 --num-gpus 2 --ulysses-degree 2 --enable-memory-bank false --save-output --enable-torch-compile --warmup --profile --profile-all-stages --perf-dump-path "$BENCH_DIR/compile-profile.json"
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch、audio codec 和 CUTLASS/Triton 已有实现，使用 ncu-report skill判断优化空间。需要新实现时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带窗口、cache、dtype、shape guard 与 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的等价操作，优先减少 global memory 读写、audio/video layout 转换、reshape/shuffle、重复 window materialize 和 CPU/GPU 往返；重点检查 modulation、norm/activation、residual、upsample+conv、mel/resample 批量化与 tile blend，保持 causal 和同步语义。
-
-7. 用独立音视频 prompt、memory-bank on/off 与长视频 soak 验收速度、显存和正确性。视频 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker，audio normalized MSE 不超过 1e-4并保持 sample count/channel/A-V sync；20 次 warmup、100 次计时且组件与 E2E 都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model joyai-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定输入图、编辑 prompt、seed、1024x1024、40 steps、guidance 4、dtype 和 topology，保存 eager output、输入 encode 与 decoder latent。比较 PSNR、SSIM、LPIPS，同时用身份/结构保持和指令完成度样本验收；CFG parallel 与纯 SP 分别建 reference。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native edit pipeline，拆分输入图 preprocess/encode、condition encoder、condition packing、DiT attention/MLP/modulation、CFG、scheduler、Wan-style causal 3D VAE decode、postprocess 和通信，记录每个阶段真实 shape 与 cache 状态。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件与 kernel 耗时，重点定位 edit encode、packed condition、attention、GEMM、A2A、causal Conv3d、resblock、upsample、tile blend、layout copy 和 graph break；用相同输入保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model joyai-edit --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实 edit shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 现有实现，再用 ncu-report skill分析热点。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带输入数、CFG、dtype、tile 和 device guard 的 kernel，并保留 fallback。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的等价操作，优先减少 global memory 读写、condition packing 的 reshape/shuffle、permute/cat、CFG materialize 和 VAE tile 临时张量；重点检查 modulation、norm/activation、residual、causal Conv3d 单帧路径、upsample+conv 和 tile blend。
-
-7. 使用未参与开发的输入图和编辑 prompt 验收精度、指令完成度、速度、显存与多卡 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且身份/结构不回归；20 次 warmup、100 次计时并确认无 fallback，收益稳定才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/krea2.md
+++ b/sglang-diffusion-optimization-flows/models/krea2.md
@@ -13,20 +13,14 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A cinematic mountain landscape" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 固定 Raw/Turbo checkpoint 配置、prompt、seed、分辨率、steps、guidance、dtype 和 topology，保存 eager 输出及 VAE latent。用固定照片、文字和细节样本比较 PSNR、SSIM、LPIPS；Cache-DiT on/off 单独建质量 reference，禁止拿 Qwen-Image 输出代替。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Krea-2 native pipeline，拆分 condition encoder、DiT attention/MLP/modulation、Cache-DiT、scheduler、AutoencoderKLQwenImage causal VAE encode/decode、tiling 和 postprocess，记录 checkpoint mapping、latent scaling、真实 shape 与 cache key/reset。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件及 kernel 耗时，重点定位 attention、GEMM、modulation、cache hit/miss、causal Conv3d、resblock、upsample、tile blend、layout copy 和 graph break；保留相同输入的 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A cinematic mountain landscape" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --profile --profile-all-stages --perf-dump-path "$BENCH_DIR/compile-profile.json"
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 的已有 kernel，使用 ncu-report skill确认瓶颈。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发 attention、cache 或 VAE kernel，保留 config/dtype/cache/device guard 与 fallback。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未完成的等价 fuse，优先减少 global memory 读写、reshape/shuffle、condition/cache materialize、layout conversion 和 tile 临时张量；重点检查 modulation、norm/activation、residual、causal Conv3d 单帧路径、upsample+conv 和 tile blend。Cache-DiT 作为近似路线分表。
-
-7. 用独立 prompt 和 Raw/Turbo 配置验收精度、速度、显存以及 cache 连续请求正确性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002；20 次 warmup、100 次计时且无 stale cache/fallback才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/lingbot-world.md
+++ b/sglang-diffusion-optimization-flows/models/lingbot-world.md
@@ -12,16 +12,14 @@ workflow 草稿
    pytest -q python/sglang/multimodal_gen/test/server/test_server_1_gpu.py -k lingbot_world_realtime_plastic_beach -s
    ~~~
 
-2. 固定 chunk、camera、prompt events、seed、resolution、fps、steps、dtype 和 topology，分别保存 V1/V2 首 chunk 与 steady-state reference。检查逐帧 PSNR/SSIM、chunk seam、prompt/camera 切换、stale frame、运动连续性、cache reset、长时显存和 steady-state FPS。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 realtime pipeline，拆分 condition encoder、camera conditioner、DiT、bounded sink-window KV cache、dynamic condition/cross-attention cache、Wan-style causal VAE、lazy black-frame encode、预分配 writer、scheduler 和 postprocess，记录 cache key、窗口、shape 与事件状态机。
+3. 分析模型架构。
 
-4. profile torch.compile 后首 chunk、steady-state chunk 和事件切换的组件/kernel 耗时，重点定位 attention、cache copy、A2A、camera packing、causal Conv3d、tile blend、writer、CPU sync 与 graph break；报告首帧延迟和稳定 FPS。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 chunk shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有实现，用 ncu-report skill分析热点。需要新 kernel 时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 window/cache/event/dtype/device guard 与 fallback 的实现。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-6. （并行）研究 compile 后仍未解决的等价 fuse，优先减少 global memory 读写、cache materialize、reshape/shuffle、condition packing、跨 rank gather 与帧缓冲复制；重点检查 modulation、norm/activation、residual、causal Conv3d、upsample+conv 和 tile blend，保持 bounded cache 与事件语义。
-
-7. 用独立长时间交互序列验收 V1/V2 的首 chunk 延迟、steady-state FPS、显存和输出正确性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，视频 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，任何 stale frame、串扰、无界 cache 或 seam 都直接拒绝；性能不够则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/longlive2.md
+++ b/sglang-diffusion-optimization-flows/models/longlive2.md
@@ -13,16 +13,14 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A long continuous walk through a city" --width 832 --height 480 --num-frames 61 --num-inference-steps 4 --guidance-scale 1.0 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 固定 prompt、seed、分辨率、fps、steps、num_frames_per_block、dtype 和 topology，保存 eager reference；latent frame 数必须可被 block size 整除。检查逐帧 PSNR/SSIM、chunk seam、运动连续、首帧条件、cache reset、长程漂移和显存有界，官方/转换 layout 分别验收。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native pipeline，拆分 condition encoder、causal DiT、block cache、4-step DMD scheduler、I2V 首帧 encode、跨 chunk memory、Wan-style causal 3D VAE decode、postprocess 和通信，记录每阶段 shape、dtype、cache key 与调用次数。
+3. 分析模型架构。
 
-4. profile torch.compile 后首 chunk 和 steady-state 的完整 E2E、组件与 kernel，重点定位 attention、cache copy、A2A、causal Conv3d、resblock、upsample、tile blend、layout materialize、CPU sync 和 graph break；保留 eager trace对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 chunk shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 的已有实现，再用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 block/cache/dtype/shape/device guard 与 fallback 的关键 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-6. （并行）研究 compile 后仍未完成的等价 fuse，优先减少 global memory 读写、cache materialize、reshape/shuffle、layout copy 和跨 chunk gather；重点检查 modulation、norm/activation、residual、causal Conv3d、upsample+conv 与 tile overlap/blend，保持 DMD 和 causal 边界。
-
-7. 用独立长视频和连续 session 验收性能、显存、cache 与正确性。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker；20 次 warmup、100 次计时，首 chunk 和 steady-state 都稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ltx.md
+++ b/sglang-diffusion-optimization-flows/models/ltx.md
@@ -15,21 +15,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-hq-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、输入图、seed、分辨率、121 帧、fps、steps、stage 切换、dtype 和 topology，保存 eager video/audio reference。比较逐帧 PSNR/SSIM、最差帧、TI2V 输入保持、时间一致性、waveform MSE、采样率和 A/V sync；one/two-stage/HQ 分别建质量基线。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 LTX pipeline，拆分 condition encoder、DiT split RoPE、attention/MLP、residual-gate add、双阶段调度、CFG parallel、AutoencoderKLLTX2Video、audio VAE/vocoder、upsampler GroupNorm+SiLU、postprocess 和通信，记录真实 shape 和调用次数。
+3. 分析模型架构。
 
-4. profile torch.compile 后各 stage、组件和 kernel，重点定位 split RoPE、attention、GEMM、A2A、residual-gate add、causal Conv3d、upsampler、tile/stream overlap、audio decode、mux 和 graph break；保留 eager trace对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-ti2v-two-stage --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对关键 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch、audio codec 和 CUTLASS/Triton 的已有 kernel，使用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 stage/causal/dtype/shape/device guard 与 fallback 的实现。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍不理想的等价 fuse，优先减少 global memory 读写、reshape/shuffle、RoPE/layout materialize、stage 间 copy 和 tile 临时张量；重点检查 QKV/RoPE/norm、residual-gate、GroupNorm+SiLU、upsample+conv、tile overlap/blend 与 audio resample。
-
-7. 用独立 TI2V、T2V 和音频样本验收 one-stage、two-stage、HQ、CFG parallel 的精度、速度、显存与 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且 A/V 同步；20 次 warmup、100 次计时并确认收益超过方差，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/minimax-h3.md
+++ b/sglang-diffusion-optimization-flows/models/minimax-h3.md
@@ -17,22 +17,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 seed 1101、1344x768 resolved canvas、5 秒、124 帧、24 fps、50 steps、video flow shift 12、audio flow shift 3、BF16/FP32 eager、TP2+Ulysses2，保存联合音视频 reference。分别跑 T2VA、FL2VA 和 Ref2VA；FL2VA 固定首尾 keyframe，Ref2VA 覆盖 image/video/audio/video_audio reference。视频检查帧数/时间戳、逐帧 PSNR/SSIM、最差帧、seam/flicker；音频检查 32 kHz stereo、sample count、waveform MSE、频谱、duration 和 A/V sync。当前 torch.compile 会改变 H3 数值输出，不能用作 lossless reference。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 H3 native pipeline，拆分 Qwen3-VL condition encoder、DiT、video/audio dual stream、MiniMaxH3VideoVAE overlapping tiled encode/decode、MiniMaxH3AudioVAE、专用 Euler ancestral eta=0 scheduler、H.264/AAC mux 和 TP/Ulysses 通信。记录真实 attention 的 tokens、heads、head_dim、RoPE dim 96、QK norm、packed QKV、indexed scale/shift/gate、USP merge、2-rank IPC A2A、batched TP AdaLN 与 final projection shape。released video VAE 禁止 spatial、spatial-shard 和 patch decode。
+3. 分析模型架构。
 
-4. 先 profile eager 的完整 T2VA 各 stage 和 kernel，再用完全相同输入单独 profile torch.compile 候选，按 DiT、video VAE、audio VAE、encoder、scheduler、通信和 mux 汇总耗时；compile 输出只用于定位，任何数值变化单独记录。重点检查 attention、GEMM、A2A、modulation、causal Conv3d、tile blend、audio Conv1d/vocoder、resample、mux、graph break 和 CPU sync。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-profile --output-dir "$BENCH_DIR" --no-torch-compile
-   # eager profile：将 helper 打印的命令原样重跑并追加 --profile --profile-all-stages
-   # compile 候选：再复制同一命令，把 --enable-torch-compile=false 替换为 --enable-torch-compile，并追加相同 profile flags
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实 H3 热点 shape 先检查源码已有的 indexed modulation、head_dim 128 fused QK norm+RoPE、packed Ulysses QKV、usp_merge_heads、IPC A2A、batched TP AdaLN 和 dead-row removal 是否命中，再调研 SGLang、FlashInfer、FlashAttention、PyTorch 和 CUTLASS/Triton 是否有更快实现；用 ncu-report skill确认 compute、memory、occupancy、launch 或通信瓶颈。需要新 kernel 时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 H3 config/dtype/shape/topology guard、exact test 与 fallback 的实现。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 eager/compile 后仍不理想的数学等价 fuse，优先减少 global memory 读写、reshape/shuffle、packed/unpacked QKV、scale-shift-gate materialize、跨 rank gather、tile overlap/blend 和 audio/video 中间张量；重点检查 QK norm+RoPE、modulation、residual、norm/activation、causal Conv、upsample+conv、vocoder/resample 与 mux 前 copy。Cache-DiT、online FP8 和少步数均作为近似路线单独验收，一次只合入一个可归因改动。
-
-7. 用开发阶段未使用的 prompt、首尾帧和 reference 资产独立验收 T2VA、FL2VA、Ref2VA，并分别测试 TP2+Ulysses2、Ulysses4；B200/B300 可追加 Ulysses8。component cosine 至少 0.999、normalized MSE 不超过 1e-4，视频 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker，音频 sample/channel/duration/A-V sync 完全满足合同；20 次 warmup、100 次计时且目标组件和 E2E 都超过方差才接受，否则回到第 4 步继续执行第 5、6 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/mova.md
+++ b/sglang-diffusion-optimization-flows/models/mova.md
@@ -13,21 +13,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model mova-720p --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定人物输入、prompt、seed、360p/720p、帧数、fps、steps、dtype 和 topology，保存 eager 视频与音频 reference。分别检查身份保持、逐帧 PSNR/SSIM、最差帧、waveform cosine/MSE、sample rate/channels、duration 和 A/V sync，禁止只验证容器可播放。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 MOVA pipeline，拆分人物 condition encoder、DiT、video/audio branches、Wan-style causal 3D VAE、DAC audio VAE、scheduler、postprocess、mux 和分布式通信，记录 360p/720p 每阶段真实 shape、dtype、调用次数和条件 packing。
+3. 分析模型架构。
 
-4. profile torch.compile 后完整 E2E、video/audio stage 与所有 kernel，重点定位 attention、GEMM、A2A、人物条件、causal Conv3d、tile blend、DAC Conv1d、resample、mux、CPU sync 与 graph break；保留 eager trace对照。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model mova-720p --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch、audio codec 和 CUTLASS/Triton 的已有实现，并用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 resolution/audio/dtype/shape/device guard 与 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、人物条件 packing、reshape/shuffle、audio/video layout 转换、tile 临时张量和 mux 前 copy；重点检查 modulation、norm/activation、residual、causal Conv、upsample+conv、DAC/resample 与 tile blend。
-
-7. 用独立人物输入和 prompt 验收 360p/720p 的精度、速度、显存和 scaling。视频 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且身份不回归，audio normalized MSE 不超过 1e-4并保持 A/V sync；20 次 warmup、100 次计时且 video/audio 组件与 E2E 都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/pi05.md
+++ b/sglang-diffusion-optimization-flows/models/pi05.md
@@ -11,16 +11,14 @@ workflow 草稿
    SGLANG_RUN_PI05_E2E=1 SGLANG_PI05_E2E_MODEL=/data/models/pi05_base SGLANG_PI05_E2E_NUM_STEPS=10 SGLANG_PI05_E2E_PERF_WARMUP=20 SGLANG_PI05_E2E_PERF_REPEAT=100 SGLANG_PI05_E2E_PERF_DUMP=/tmp/pi05-baseline.json pytest -q python/sglang/multimodal_gen/test/single_test_file/test_pi05_e2e.py
    ~~~
 
-2. 固定 task、三路 224x224 camera、32-d state、action horizon 50、action dim 32、10 denoise steps、dtype、batch 和 topology，保存 eager action reference。比较 action shape、finite、normalized MSE、cosine、p50/p95 和 replay/仿真任务成功率；cache on/off、不同 camera/state/task 与连续 session 必须一致。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Pi0.5 架构，拆分 image preprocess/vision tower、PaliGemma prefix、prefix cache、action expert、10-step action denoise、action head、CUDA graph、序列化和 TP/SP；该模型没有 VAE，不使用图像或视频重建指标代替 action correctness。
+3. 分析模型架构。
 
-4. profile torch.compile 后 prefix、denoise 和 action head 的组件/kernel 耗时，重点定位 vision attention/GEMM、prefix cache copy、action expert attention/MLP、small-batch launch、CUDA graph、序列化、通信与 graph break；保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对真实 batch/sequence/action shape 调研 SGLang、FlashInfer、FlashAttention、PyTorch 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill分析性能空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 camera/state/cache/dtype/shape/device guard、测试和 fallback 的关键 kernel。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-6. （并行）研究 compile 后仍未融合好的等价操作，优先减少 global memory 读写、prefix/action layout 转换、reshape/shuffle、cache materialize、small tensor launch 和序列化 copy；重点检查 QKV/RoPE/norm、modulation、residual、action-step update 与 batched request packing。
-
-7. 用独立 replay episode 验收 pi05_base 与 LIBERO checkpoint 的 action 精度、p50/p95、吞吐、显存和多 session 正确性。normalized MSE 与 cosine 必须在预设容差内且任务成功率不回归；20 次 warmup、100 次计时，prefix/denoise 和端到端均稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/qwen-image.md
+++ b/sglang-diffusion-optimization-flows/models/qwen-image.md
@@ -15,21 +15,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、输入图、seed、分辨率、steps、guidance、dtype 和 topology，保存 T2I/Edit/Layered 的 eager output、encode 与 latent reference。比较 PSNR、SSIM、LPIPS、文字和编辑保持；Layered 另验层数、alpha、ordering，NVFP4 与 FireRed 分别建立质量预算。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native pipeline，拆分 Qwen condition encoder、DiT attention/MLP/modulation、fused QK norm/RoPE、packed sequence、多图 condition packing、CFG/TP、scheduler、AutoencoderKLQwenImage causal VAE、tiling 和 postprocess，记录各 variant 真实 shape。
+3. 分析模型架构。
 
-4. profile torch.compile 后各 stage、组件和 kernel，重点定位 attention、GEMM、QK norm/RoPE、modulation、多图 packing、CFG、causal Conv3d、resblock、upsample、tile blend、A2A 与 graph break；保留相同输入的 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model qwen-edit --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 variant/input-count/layer/dtype/shape/device guard 与 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的数学等价操作，优先减少 global memory 读写、reshape/shuffle、packed layout 转换、多图 condition materialize、CFG copy 和 tile 临时张量；重点检查 QK norm+RoPE、modulation、residual、causal Conv3d 单帧路径、upsample+conv 与 tile blend。
-
-7. 用独立 T2I、Edit、Layered 和 FireRed 样本验收精度、速度、显存与多卡 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且编辑/层语义不回归；20 次 warmup、100 次计时且无 fallback/cache 污染才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/sana.md
+++ b/sglang-diffusion-optimization-flows/models/sana.md
@@ -15,16 +15,14 @@ workflow 草稿
    sglang generate --backend sglang --model-path Efficient-Large-Model/SANA-WM_streaming --prompt "The subject slowly turns toward the camera" --image-path /tmp/sana-wm-input.png --width 640 --height 384 --num-frames 17 --fps 16 --num-inference-steps 12 --guidance-scale 4.5 --seed 0 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/sana-wm-baseline.json"
    ~~~
 
-2. SANA 图像固定 prompt、seed、512/1024、steps 和 dtype，用重建集比较 PSNR、SSIM、LPIPS、文字和细线；SANA-WM 固定输入图、prompt、seed、chunk、帧数、fps 和 topology，比较逐帧 PSNR/SSIM、首帧、chunk seam、steady-state FPS、cache reset 和长时显存。600M/1.6B/4.8B、bidirectional/streaming 分开建 reference。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析两条 native pipeline。SANA 拆分 encoder、DiT、scheduler、AutoencoderDC 和 postprocess；SANA-WM 拆分 encoder、causal DiT/cache、scheduler、AutoencoderKLLTX2Video、streaming/tile state 和通信。分别记录真实 shape、dtype、调用次数与 cache 合同。
+3. 分析模型架构。
 
-4. profile torch.compile 后各自的组件与 kernel 耗时，SANA 重点检查 attention/GEMM、DC-AE conv/channel mixing/upsample；SANA-WM 重点检查 causal attention/cache、A2A、causal Conv3d、upsampler、chunk/tile blend、CPU sync 和 graph break；都保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-5. （并行）针对两条 pipeline 的真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 现有实现，并用 ncu-report skill分析空间。需要新 kernel 时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 model/stream/cache/dtype/shape/device guard 与 fallback 的实现。
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-6. （并行）研究 compile 后仍未处理好的等价 fuse，优先减少 global memory 读写、reshape/shuffle、cache/materialize、layout 转换和 tile 临时张量；SANA 重点看 norm/activation、residual、upsample+conv，SANA-WM 重点看 causal cache、Conv3d、upsampler 与 chunk blend。
-
-7. 用独立图像与长视频输入验收两条 pipeline。component cosine 至少 0.999、normalized MSE 不超过 1e-4，图像/逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002，streaming 无 seam/flicker且显存有界；20 次 warmup、100 次计时，组件与 E2E 都超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
+++ b/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
@@ -14,20 +14,14 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A studio photograph of a red fox" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 固定 prompt、seed、1024px、steps、guidance、dtype 和 topology，保存 eager 图像、CLIP/T5 condition、DiT 输出和 VAE latent。使用固定 ImageNet-val 子集或重建集比较 PSNR、SSIM、LPIPS、颜色和文字；Medium/Large、裸 checkpoint/Diffusers layout 分别建 reference。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 native pipeline，拆分 CLIP/T5 encoder、MMDiT joint attention/MLP/modulation、scheduler、AutoencoderKL 2D conv/resblock/mid attention/upsample/tile 和 postprocess，记录 config、latent scaling、真实 shape 与 backend dispatch。
+3. 分析模型架构。
 
-4. profile torch.compile 后的完整 E2E 和所有 stage，重点定位 encoder、joint attention、GEMM、modulation、decoder conv/resblock、GroupNorm/SiLU、mid attention、upsample、tile blend 和 graph break；用 eager trace确认没有 Diffusers backend fallback。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A studio photograph of a red fox" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --profile --profile-all-stages --perf-dump-path "$BENCH_DIR/compile-profile.json"
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 model-size/layout/dtype/shape/device guard、测试和 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未完成的数学等价 fuse，优先减少 global memory 读写、reshape/shuffle、CLIP/T5 condition materialize 和 VAE tile 临时张量；重点检查 QKV/RoPE/norm、modulation、residual、GroupNorm+SiLU、upsample+conv 与 tile overlap/blend。
-
-7. 用独立 prompt 和重建样本验收 Medium/Large 与两种 layout 的精度、速度、显存和 native loader。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002；20 次 warmup、100 次计时且无 fallback、组件和 E2E 都稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/wan.md
+++ b/sglang-diffusion-optimization-flows/models/wan.md
@@ -15,21 +15,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model fastwan22-ti2v-5b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、输入图、seed、resolution、frames、fps、steps、dtype 和 topology，保存 eager T2V/I2V/TI2V reference。比较逐帧 PSNR/SSIM、最差帧、输入图保持、运动、首尾和闪烁；1.3B/5B/A14B、蒸馏/少步数、NVFP4 分别建立质量预算。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Wan native pipeline，拆分 text/image encoder、DiT attention/MLP/modulation、packed layout、scheduler、AutoencoderKLWan causal 3D encode/decode、temporal/spatial/patch tiling、postprocess、CFG/Ulysses 通信与 offload，记录真实 shape 和合法并行组合。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件和 kernel 耗时，重点定位 attention、GEMM、A2A/all-gather、packed layout、modulation、causal Conv3d、norm、resblock、upsample、tile blend、offload copy 与 graph break；保留相同输入的 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model wan-ti2v --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill判断计算、访存或通信空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 task/model/dtype/tile/topology/device guard 与 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未融合好的数学等价路径，优先减少 global memory 读写、reshape/shuffle、packed layout 转换、CFG materialize、跨 rank gather 和 tile 临时张量；重点检查 QKV/RoPE/norm、modulation、residual、causal Conv3d 单帧路径、upsample+conv 与 tile overlap/blend。
-
-7. 用独立 T2V/I2V/TI2V 输入验收 1.3B/5B/A14B 及目标 variant 的精度、速度、显存和多卡 scaling。component cosine 至少 0.999、normalized MSE 不超过 1e-4，逐帧 PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002且无 seam/flicker；20 次 warmup、100 次计时且收益超过方差才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/z-image.md
+++ b/sglang-diffusion-optimization-flows/models/z-image.md
@@ -15,21 +15,14 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model zimage-base --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 固定 prompt、seed、resolution、steps、guidance、dtype 和 topology，分别保存 Base/Turbo 的 eager 图像、DiT 输出和 VAE latent。用固定 ImageNet-val 子集或重建集比较 PSNR、SSIM、LPIPS、颜色和细节；Base 与 Turbo 的步数/质量不得混表。
+2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
 
-3. 分析 Z-Image native pipeline，拆分 condition encoder、DiT attention/MLP/modulation、bf16 Triton norm/tanh residual、scheduler、AutoencoderKL 2D conv/resblock/mid attention/upsample/tile 和 postprocess，记录真实 shape、dtype 与 fast-path dispatch。
+3. 分析模型架构。
 
-4. profile torch.compile 后各组件及 kernel 耗时，先确认现有 bf16 Triton norm/tanh residual 是否命中，再定位 attention、GEMM、modulation、decoder conv、GroupNorm/SiLU、upsample、tile blend 和 graph break；保留 eager trace。
+4. profile torch.compile 后各组件耗时和各种 kernel 耗时，定位关键 kernel 和可以 fuse 的部分。
 
-   ~~~bash
-   PYTHONPATH=python python3 "$BENCH_PY" --model zimage --label compile-baseline --output-dir "$BENCH_DIR"
-   # 将 helper 打印的 sglang generate 命令原样重跑，并追加：--profile --profile-all-stages
-   ~~~
+5. （并行）对于关键 kernel，首先调研是否已经存在对应 GPU 架构和参数下的高性能实现，之后使用 ncu-report skill profile 是否还有优化空间。需要开发时启动 kernel design sub agent，使用 ultra 模式，并结合 KernelWiki 和 ncu-report skill。如果 profile 明确确认模型受 attention 限制，则 fork 当前 SGLang 使用的 FlashAttention，针对真实 shape 修改并验证。
 
-5. （并行）针对真实热点 shape 调研 SGLang、FlashInfer、FlashAttention、Diffusers、PyTorch 和 CUTLASS/Triton 已有 kernel，并用 ncu-report skill确认现有 Triton fast path 和其他热点的优化空间。必要时启动 kernel design sub agent，以 ultra 模式结合 KernelWiki 和 ncu-report skill开发带 base/turbo/dtype/shape/device guard、测试和 fallback 的关键 kernel。
+6. （并行）研究 compile 后仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-   如果 trace/NCU 明确证明 attention-bound，则必须立即 fork 当前 SGLang 所依赖版本的 FlashAttention，在 fork 中针对真实 head_dim、token、layout 和 GPU 架构修改 kernel 与 dispatch；特别覆盖 FlashAttention/cuDNN 当前不支持的 head_dim 384/512 等盲区，并让 SGLang 显式指向该 fork。不得只停留在调研或另写旁路原型；所有非目标 shape 保持 fail-closed 回退，最后用原模型、相同输入、NCU 与端到端精度/性能共同验收。
-
-6. （并行）研究 compile 后仍未完成的数学等价 fuse，优先减少 global memory 读写、reshape/shuffle、condition materialize 和 tile 临时张量；重点检查 norm+tanh residual、QKV/RoPE、modulation、GroupNorm+SiLU、residual、upsample+conv 与 tile overlap/blend。
-
-7. 用独立 prompt 和重建样本验收 Base/Turbo 的精度、速度、显存和 native dispatch。component cosine 至少 0.999、normalized MSE 不超过 1e-4，PSNR 下降不超过 0.10 dB、SSIM 下降不超过 0.002；20 次 warmup、100 次计时且组件和 E2E 都稳定获益才接受，否则回到第 4 步。
+7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。


### PR DESCRIPTION
## Summary

- simplify all 22 model and 11 VAE optimization flows to the same focused seven-step workflow
- keep each document self-contained, including its model download and benchmark commands
- direct model baselines to the latest SGLang Diffusion benchmark/profile skill
- remove universal cosine, MSE, PSNR, and SSIM thresholds that could prematurely constrain agent exploration
- keep the FlashAttention fork rule only in model flows when profiling proves attention-bound

## Validation

- verified every document contains exactly steps 1 through 7
- verified all model flows reference the benchmark/profile skill
- verified VAE flows do not contain the FlashAttention fork rule
- verified every checked-in benchmark preset exists on current SGLang main
- ran git diff --check