### PR TITLE
Align diffusion quality gates with Sol Engine

### DIFF
--- a/sglang-diffusion-optimization-flows/components/vae-audio.md
+++ b/sglang-diffusion-optimization-flows/components/vae-audio.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定音频重建数据集上的精度，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
+++ b/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model sana-1.5-1.6b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-flux2.md
+++ b/sglang-diffusion-optimization-flows/components/vae-flux2.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定 shape 重建数据集上的精度，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-ti2v-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试 ImageNet-val 数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
+++ b/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试对应重建数据集上的精度，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model wan-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 测试固定视频重建数据集上的 PSNR，建立优化前的精度基线。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/cosmos3.md
+++ b/sglang-diffusion-optimization-flows/models/cosmos3.md
@@ -16,7 +16,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model cosmos3-super-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -26,4 +26,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ernie-image.md
+++ b/sglang-diffusion-optimization-flows/models/ernie-image.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ernie-image-turbo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/flux.md
+++ b/sglang-diffusion-optimization-flows/models/flux.md
@@ -17,7 +17,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2-klein --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -27,4 +27,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/glm-image.md
+++ b/sglang-diffusion-optimization-flows/models/glm-image.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model glm-image --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/helios.md
+++ b/sglang-diffusion-optimization-flows/models/helios.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model helios --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/hunyuan.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/hunyuan3d.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ideogram4.md
+++ b/sglang-diffusion-optimization-flows/models/ideogram4.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ideogram4-fp8 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/joyai-echo.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-echo.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A curious raccoon" --width 640 --height 384 --num-frames 33 --num-inference-steps 8 --seed 42 --num-gpus 2 --ulysses-degree 2 --enable-memory-bank false --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model joyai-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/krea2.md
+++ b/sglang-diffusion-optimization-flows/models/krea2.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A cinematic mountain landscape" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/lingbot-world.md
+++ b/sglang-diffusion-optimization-flows/models/lingbot-world.md
@@ -12,7 +12,7 @@ workflow 草稿
    pytest -q python/sglang/multimodal_gen/test/server/test_server_1_gpu.py -k lingbot_world_realtime_plastic_beach -s
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -22,4 +22,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/longlive2.md
+++ b/sglang-diffusion-optimization-flows/models/longlive2.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A long continuous walk through a city" --width 832 --height 480 --num-frames 61 --num-inference-steps 4 --guidance-scale 1.0 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/ltx.md
+++ b/sglang-diffusion-optimization-flows/models/ltx.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-hq-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -25,4 +25,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/minimax-h3.md
+++ b/sglang-diffusion-optimization-flows/models/minimax-h3.md
@@ -17,7 +17,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -27,4 +27,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/mova.md
+++ b/sglang-diffusion-optimization-flows/models/mova.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model mova-720p --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -23,4 +23,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/pi05.md
+++ b/sglang-diffusion-optimization-flows/models/pi05.md
@@ -11,7 +11,7 @@ workflow 草稿
    SGLANG_RUN_PI05_E2E=1 SGLANG_PI05_E2E_MODEL=/data/models/pi05_base SGLANG_PI05_E2E_NUM_STEPS=10 SGLANG_PI05_E2E_PERF_WARMUP=20 SGLANG_PI05_E2E_PERF_REPEAT=100 SGLANG_PI05_E2E_PERF_DUMP=/tmp/pi05-baseline.json pytest -q python/sglang/multimodal_gen/test/single_test_file/test_pi05_e2e.py
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -21,4 +21,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/qwen-image.md
+++ b/sglang-diffusion-optimization-flows/models/qwen-image.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -25,4 +25,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/sana.md
+++ b/sglang-diffusion-optimization-flows/models/sana.md
@@ -15,7 +15,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path Efficient-Large-Model/SANA-WM_streaming --prompt "The subject slowly turns toward the camera" --image-path /tmp/sana-wm-input.png --width 640 --height 384 --num-frames 17 --fps 16 --num-inference-steps 12 --guidance-scale 4.5 --seed 0 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/sana-wm-baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -25,4 +25,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
+++ b/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
@@ -14,7 +14,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A studio photograph of a red fox" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -24,4 +24,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/wan.md
+++ b/sglang-diffusion-optimization-flows/models/wan.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model fastwan22-ti2v-5b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -25,4 +25,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。

--- a/sglang-diffusion-optimization-flows/models/z-image.md
+++ b/sglang-diffusion-optimization-flows/models/z-image.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model zimage-base --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端精度基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 
@@ -25,4 +25,4 @@ workflow 草稿
 
 6. （并行）研究当前执行模式下仍未处理好的 fuse 机会，重点减少 global memory 读写、reshape 和 shuffle。优先研究数学等价操作的融合，例如 upsampling 与 convolution；其次研究 kernel 内部融合以减少访存。
 
-7. 用独立输入验收改进后的精度和速度。精度验收不要求 bit-identical，使用合理误差范围。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。
+7. 用独立输入验收改进后的质量和速度，并重复与基线相同的 Sol Engine quality-gated 评测。不要求 bitwise match；只要质量指标和 Agent 内置质量评审都在预先设定的可接受范围内，就认为精度通过。如果结果还不够好就回到第 4 步，再次执行第 5、6 步。


### PR DESCRIPTION
## Summary

- align all model and VAE flow quality checks with the Sol Engine quality-gated pattern
- freeze fixed inputs and baseline outputs before optimization
- use output-domain quality metrics, including aligned LPIPS for images and videos
- require the agent built-in quality review alongside metrics
- accept non-bitwise numerical movement when quality stays inside a predeclared acceptable range

## Why

The previous wording mixed ImageNet PSNR, generic accuracy, and loosely defined numeric tolerances. This could either overconstrain mathematically valid optimizations or apply an irrelevant metric to a non-image modality.

## Validation

- updated all 22 model and 11 VAE flows
- verified all 33 baseline steps use the Sol Engine quality-gated policy
- verified all 33 acceptance steps explicitly reject bitwise matching as a requirement
- verified no stale step-2 PSNR-only rules or bit-identical wording remain
- ran git diff --check