### PR TITLE
Link diffusion flows to the Sol Engine branch

### DIFF
--- a/sglang-diffusion-optimization-flows/components/vae-audio.md
+++ b/sglang-diffusion-optimization-flows/components/vae-audio.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-autoencoder-kl-2d.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
+++ b/sglang-diffusion-optimization-flows/components/vae-dc-ae.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model sana-1.5-1.6b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-flux2.md
+++ b/sglang-diffusion-optimization-flows/components/vae-flux2.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan-video.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
+++ b/sglang-diffusion-optimization-flows/components/vae-hunyuan3d-shape.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-ltx-video.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-ti2v-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
+++ b/sglang-diffusion-optimization-flows/components/vae-minimax-h3-video.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-qwen-causal-3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
+++ b/sglang-diffusion-optimization-flows/components/vae-rewrite-candidates.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
+++ b/sglang-diffusion-optimization-flows/components/vae-wan-causal-3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model wan-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立 VAE 组件质量基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析 decoder 架构。
 

--- a/sglang-diffusion-optimization-flows/models/cosmos3.md
+++ b/sglang-diffusion-optimization-flows/models/cosmos3.md
@@ -16,7 +16,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model cosmos3-super-t2v --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/ernie-image.md
+++ b/sglang-diffusion-optimization-flows/models/ernie-image.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ernie-image-turbo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/flux.md
+++ b/sglang-diffusion-optimization-flows/models/flux.md
@@ -17,7 +17,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model flux2-klein --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/glm-image.md
+++ b/sglang-diffusion-optimization-flows/models/glm-image.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model glm-image --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/helios.md
+++ b/sglang-diffusion-optimization-flows/models/helios.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model helios --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/hunyuan.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuanvideo --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/hunyuan3d.md
+++ b/sglang-diffusion-optimization-flows/models/hunyuan3d.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model hunyuan3d-shape --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/ideogram4.md
+++ b/sglang-diffusion-optimization-flows/models/ideogram4.md
@@ -14,7 +14,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ideogram4-fp8 --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/joyai-echo.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-echo.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A curious raccoon" --width 640 --height 384 --num-frames 33 --num-inference-steps 8 --seed 42 --num-gpus 2 --ulysses-degree 2 --enable-memory-bank false --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
+++ b/sglang-diffusion-optimization-flows/models/joyai-image-edit.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model joyai-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/krea2.md
+++ b/sglang-diffusion-optimization-flows/models/krea2.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A cinematic mountain landscape" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/lingbot-world.md
+++ b/sglang-diffusion-optimization-flows/models/lingbot-world.md
@@ -12,7 +12,7 @@ workflow 草稿
    pytest -q python/sglang/multimodal_gen/test/server/test_server_1_gpu.py -k lingbot_world_realtime_plastic_beach -s
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/longlive2.md
+++ b/sglang-diffusion-optimization-flows/models/longlive2.md
@@ -13,7 +13,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A long continuous walk through a city" --width 832 --height 480 --num-frames 61 --num-inference-steps 4 --guidance-scale 1.0 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/ltx.md
+++ b/sglang-diffusion-optimization-flows/models/ltx.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model ltx23-hq-two-stage --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/minimax-h3.md
+++ b/sglang-diffusion-optimization-flows/models/minimax-h3.md
@@ -17,7 +17,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model minimax-h3-t2va --label eager-baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/mova.md
+++ b/sglang-diffusion-optimization-flows/models/mova.md
@@ -13,7 +13,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model mova-720p --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/pi05.md
+++ b/sglang-diffusion-optimization-flows/models/pi05.md
@@ -11,7 +11,7 @@ workflow 草稿
    SGLANG_RUN_PI05_E2E=1 SGLANG_PI05_E2E_MODEL=/data/models/pi05_base SGLANG_PI05_E2E_NUM_STEPS=10 SGLANG_PI05_E2E_PERF_WARMUP=20 SGLANG_PI05_E2E_PERF_REPEAT=100 SGLANG_PI05_E2E_PERF_DUMP=/tmp/pi05-baseline.json pytest -q python/sglang/multimodal_gen/test/single_test_file/test_pi05_e2e.py
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/qwen-image.md
+++ b/sglang-diffusion-optimization-flows/models/qwen-image.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model qwen-edit --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/sana.md
+++ b/sglang-diffusion-optimization-flows/models/sana.md
@@ -15,7 +15,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path Efficient-Large-Model/SANA-WM_streaming --prompt "The subject slowly turns toward the camera" --image-path /tmp/sana-wm-input.png --width 640 --height 384 --num-frames 17 --fps 16 --num-inference-steps 12 --guidance-scale 4.5 --seed 0 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/sana-wm-baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
+++ b/sglang-diffusion-optimization-flows/models/stable-diffusion-3.md
@@ -14,7 +14,7 @@ workflow 草稿
    sglang generate --backend sglang --model-path "$MODEL_DIR" --prompt "A studio photograph of a red fox" --width 1024 --height 1024 --seed 42 --save-output --enable-torch-compile --warmup --perf-dump-path "$BENCH_DIR/baseline.json"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/wan.md
+++ b/sglang-diffusion-optimization-flows/models/wan.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model fastwan22-ti2v-5b --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 

--- a/sglang-diffusion-optimization-flows/models/z-image.md
+++ b/sglang-diffusion-optimization-flows/models/z-image.md
@@ -15,7 +15,7 @@ workflow 草稿
    PYTHONPATH=python python3 "$BENCH_PY" --model zimage-base --label baseline --output-dir "$BENCH_DIR"
    ~~~
 
-2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine 的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
+2. 使用固定输入建立模型端到端质量基线。从 SGLang Diffusion 的 `sglang-diffusion-benchmark-profile` skill 中查找并执行该模型的 benchmark 命令；如果没有现成 preset，则按该 skill 的命令格式建立基线。保存基线输出，并按 Sol Engine（[NVlabs/Sana `sol-engine` 分支](https://github.com/NVlabs/Sana/tree/sol-engine)）的 quality-gated 方式记录与输出模态匹配的质量指标（图像和视频使用对齐 LPIPS）和 Agent 内置质量评审结果。
 
 3. 分析模型架构。
 


### PR DESCRIPTION
## Summary

- link every model and VAE flow directly to the official NVlabs/Sana sol-engine branch
- keep the quality-gated source traceable from each standalone document

## Why

The repository-local Sol adapter was removed, so an unlinked Sol Engine reference did not identify the authoritative upstream implementation. Each flow is intentionally standalone and should carry its own source link.

## Validation

- confirmed the upstream sol-engine branch currently resolves
- verified all 33 flows contain the branch link
- verified no unlinked policy phrase remains
- ran git diff --check