### PR TITLE
Add Torch Profiler layer guide track skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "ai-infra-auto-driven-skills",
       "source": "./",
       "description": "LLM serving benchmarks, SGLang model Day-0 support, profiling, SGLang/vLLM SOTA loops, code review, prod incident triage, and PR-history dossiers.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "category": "ai-infra",
       "tags": ["sglang", "day0", "vllm", "tensorrt-llm", "benchmarks", "profiler", "kernel", "moe", "llm-serving"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-infra-auto-driven-skills",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent-ready playbooks for LLM serving benchmarks, SGLang model Day-0 support, capacity planning, profiling, SGLang/vLLM SOTA loops, code review, incidents, and PR-history dossiers.",
   "author": {
     "name": "BBuf",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and model PR intelligence.**
 [![GitHub stars](https://img.shields.io/github/stars/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/forks)
 [![Last commit](https://img.shields.io/github/last-commit/BBuf/AI-Infra-Auto-Driven-SKILLS?style=flat-square)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/commits/main)
-[![Core skills](https://img.shields.io/badge/core_skills-11-2f80ed?style=flat-square)](#core-skills)
+[![Core skills](https://img.shields.io/badge/core_skills-12-2f80ed?style=flat-square)](#core-skills)
 [![PR histories](https://img.shields.io/badge/pr_histories-72-2ea44f?style=flat-square)](#model-pr-history-catalog)
 [![KDA-Pilot](https://img.shields.io/badge/sibling-KDA--Pilot-ff7b72?style=flat-square)](https://github.com/BBuf/KDA-Pilot)
 
@@ -49,6 +49,7 @@ find it.
 | [`llm-serving-capacity-planner`](skills/llm-serving-capacity-planner/) | You need to explain SGLang or vLLM startup memory, KV cache budget, request capacity, or OOM pressure from logs. |
 | [`llm-torch-profiler-analysis`](skills/llm-torch-profiler-analysis/) | You need a three-table profiler report that keeps `extend/prefill` and `decode` evidence separate. |
 | [`llm-pipeline-analysis`](skills/llm-pipeline-analysis/) | You need forward-pass, layer, and kernel-level timing from a torch profiler trace, including anchor boundaries and Perfetto ranges. |
+| [`torch-profiler-layer-track`](skills/torch-profiler-layer-track/) | You want numbered layer guide tracks next to GPU kernels in Perfetto, with verified anchors and preserved CPU/GPU events. |
 | [`model-compute-simulation`](skills/model-compute-simulation/) | You need operator shapes, FLOPs, MFU estimates, kernel-to-op mapping, or parallelism what-if analysis for an LLM serving shape. |
 | [`sglang-model-day0-support`](skills/model-optimization/sglang-model-day0-support/) | You need to turn a new SGLang model architecture into a public Day-0 PR DAG, parallel/kernel adaptation plan, seven-gate validation matrix, release lock, and sanitized evidence bundle. |
 | [`sglang-humanize-review`](skills/sglang-humanize-review/) | You need SGLang code-review findings grounded in full human PR review episodes from project start through the latest corpus refresh (collected through 2026-07-27), including inline code context, top-level discussion, review summaries, and multi-round replies. Every review opens with a PR comprehension pass — a change summary plus a Mermaid execution flowchart with the diff's modified steps marked — so the reviewer sees how the PR runs before the findings. |
@@ -180,7 +181,7 @@ installed as a single Claude Code plugin via the built-in marketplace flow:
 /reload-plugins
 ```
 
-After reload, the 11 skills appear namespaced as
+After reload, the 12 skills appear namespaced as
 `ai-infra-auto-driven-skills:<skill-name>` (for example
 `ai-infra-auto-driven-skills:sglang-sota-humanize-loop`). Update later with
 `/plugin marketplace update ai-infra-auto-driven-skills`.
@@ -200,6 +201,7 @@ ln -s "$PWD/skills/llm-serving-auto-benchmark" ~/.claude/skills/llm-serving-auto
 ln -s "$PWD/skills/llm-serving-capacity-planner" ~/.claude/skills/llm-serving-capacity-planner
 ln -s "$PWD/skills/llm-torch-profiler-analysis" ~/.claude/skills/llm-torch-profiler-analysis
 ln -s "$PWD/skills/llm-pipeline-analysis" ~/.claude/skills/llm-pipeline-analysis
+ln -s "$PWD/skills/torch-profiler-layer-track" ~/.claude/skills/torch-profiler-layer-track
 ln -s "$PWD/skills/model-compute-simulation" ~/.claude/skills/model-compute-simulation
 ln -s "$PWD/skills/model-optimization/sglang-model-day0-support" ~/.claude/skills/sglang-model-day0-support
 ln -s "$PWD/skills/sglang-humanize-review" ~/.claude/skills/sglang-humanize-review
@@ -213,7 +215,7 @@ ln -s "$PWD/model-pr-optimization-history" ~/.claude/skills/model-pr-history-kno
 Restart Claude Code after installing. The skills can then be invoked by name,
 for example `[$llm-serving-auto-benchmark]`,
 `[$llm-serving-capacity-planner]`, `[$llm-torch-profiler-analysis]`,
-`[$llm-pipeline-analysis]`, `[$model-compute-simulation]`,
+`[$llm-pipeline-analysis]`, `[$torch-profiler-layer-track]`, `[$model-compute-simulation]`,
 `[$sglang-model-day0-support]`,
 `[$sglang-humanize-review]`,
 `[$sglang-sota-humanize-loop]`, or `[$vllm-sota-humanize-loop]`.
@@ -233,6 +235,7 @@ cp -R skills/llm-serving-auto-benchmark <agent-skill-dir>/llm-serving-auto-bench
 cp -R skills/llm-serving-capacity-planner <agent-skill-dir>/llm-serving-capacity-planner
 cp -R skills/llm-torch-profiler-analysis <agent-skill-dir>/llm-torch-profiler-analysis
 cp -R skills/llm-pipeline-analysis <agent-skill-dir>/llm-pipeline-analysis
+cp -R skills/torch-profiler-layer-track <agent-skill-dir>/torch-profiler-layer-track
 cp -R skills/model-compute-simulation <agent-skill-dir>/model-compute-simulation
 cp -R skills/model-optimization/sglang-model-day0-support <agent-skill-dir>/sglang-model-day0-support
 cp -R skills/sglang-humanize-review <agent-skill-dir>/sglang-humanize-review
@@ -277,6 +280,7 @@ skills/
 ├── llm-serving-capacity-planner/     # startup memory and request capacity analysis
 ├── llm-torch-profiler-analysis/     # profiler capture and trace triage
 ├── llm-pipeline-analysis/           # forward/layer/kernel trace analysis
+├── torch-profiler-layer-track/      # numbered GPU layer guide tracks
 ├── model-compute-simulation/        # operator FLOPs, tensor shapes, and MFU
 ├── sglang-humanize-review/          # human SGLang PR review corpus and workflow
 ├── sglang-sota-humanize-loop/       # Humanize-governed SGLang SOTA loop

--- a/skills/torch-profiler-layer-track/SKILL.md
+++ b/skills/torch-profiler-layer-track/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: torch-profiler-layer-track
+description: Add numbered layer guide tracks to an existing Torch Profiler Chrome JSON trace for Perfetto navigation. Use when a user wants L0/L1/... labels next to GPU kernels, help counting model layers, or an annotated local trace and screenshot.
+---
+
+# Torch Profiler Layer Track
+
+Turn a verified, once-per-layer GPU anchor into a separate `L0, L1, ...`
+navigation track. Preserve original CPU/GPU events and timestamps. The output
+is a normal Chrome JSON trace; it does not depend on a saved browser workspace.
+
+## Establish what the labels mean
+
+Use the user's existing local trace, including a Desktop copy when requested.
+Obtain the layer count from matching model config/source. Identify the rank/GPU,
+execution phase, and one complete forward pass before counting. In speculative
+decoding, separate target verify from draft passes. BS=1 does not imply one
+token per target verify. A repeated block in the overview can be a whole
+iteration, not a transformer layer.
+
+Choose a GPU kernel that occurs **exactly once per layer in the selected
+phase**. Verify its call site and cross-check the count with another landmark
+or CPU module scopes. Record this evidence and code revision. Names, stream
+numbers and layer counts depend on the model/build; do not count all Top-K
+calls or blindly reuse a previous model's anchor. Inspect all GPU streams in
+the rank: layers can change streams. CPU scopes mark host launch intervals,
+not GPU execution boundaries.
+
+The helper does not guess L0 from counts alone. `--anchor-offset` must identify
+a verified first layer in timestamp-sorted matching events. Divisibility does
+not rule out a partial first pass or mixed draft/target anchors. If evidence
+is insufficient, explain the ambiguity instead of publishing confident labels.
+
+## Add the auxiliary track
+
+Scripts require Python 3.10+ and the standard library only. Commands are
+relative to this skill directory.
+
+```bash
+python3 scripts/add_layer_track.py \
+  --trace /path/to/TP-0.trace.json.gz \
+  --output /path/to/TP-0.layers.trace.json \
+  --anchor-regex '^YOUR_ONCE_PER_LAYER_KERNEL$' \
+  --num-layers 40 --anchor-offset 0 --passes 1 \
+  --phase target-verify \
+  --evidence 'Config/source revision ...; first L0 verified; 40 anchors per target pass; draft uses a different path.'
+```
+
+- Use `--pid GPU_PID` when anchors occur in multiple processes/GPUs.
+  Use `--device DEVICE` if a single PID contains anchors from multiple devices.
+- `--passes` labels only that many complete passes. `--first-layer` supports
+  a known pipeline partition. A truncated selection is rejected.
+- Optional `--end-anchor-regex` identifies a verified layer-ending kernel
+  occurring once between anchors and closes the final label of each pass.
+  Without it, the last label is a zero-duration marker; L39 is never extended
+  across a draft pass or an inter-iteration gap.
+- `.json` and `.json.gz` input/output work. Output must be a new file. A mapping
+  report is saved as `<output>.layers.json`.
+
+Every interval is a **guide**, from this layer's anchor to the next layer's
+anchor. Work before the anchor is outside its guide. The last interval, when
+supplied, ends at a terminal kernel's completion. These are not full layer
+boundaries, exclusive kernel ownership, or per-layer latency measurements.
+Overlapping streams can cross labels. Numbering is zero-based: **L2 is the
+third transformer layer**.
+Only auxiliary endpoints are rounded to the nearest microsecond to avoid
+floating-point overlaps; original timestamps and report anchor values stay intact.
+
+## Open and inspect
+
+Open the annotated file with Perfetto's **Open trace file**. Expand the selected
+GPU/process, locate `Layer guide (...) — anchor intervals`, and pin it beside
+the GPU streams. Use relative times in the report to locate L0, L1, a middle
+layer and the final layer.
+
+If the browser cannot fetch a local trace URL, use the loopback viewer. It
+transfers local bytes after Perfetto's PING/PONG handshake:
+
+```bash
+python3 scripts/serve_local_trace.py --trace /path/to/TP-0.layers.trace.json
+# Open the printed http://127.0.0.1:PORT/ in the user's chosen browser.
+# macOS example:
+open -a Firefox http://127.0.0.1:PORT/
+```
+
+The server exposes only this trace and its viewer until Ctrl-C. It needs network
+access for the Perfetto UI; it does not upload the trace to storage. Manual
+file opening works when the UI is locally available. See
+[navigation.md](references/navigation.md) for SQL checks, screenshot guidance,
+time units, and the DeepSeek-V4.1 example.
+
+## Verify and deliver
+
+1. Check the report's PID, layer count, anchor offset, phase and source hash
+   against the intended trace. Check two passes when claiming the mapping
+   repeats across iterations.
+2. Verify every original event and metadata value is retained and Perfetto
+   imports the expected marker count. The report records counts; direct JSON
+   comparison provides stronger verification.
+3. Inspect the guide beside the GPU kernels. If requested, capture the real
+   viewer with readable labels and relevant streams. Preserve CPU tracks/flows
+   when present; labels cannot reconstruct CPU events absent from the capture.
+4. Return the annotated trace, report, and screenshot if requested. State the
+   numbering convention and anchor-boundary limitation. Keep large traces and
+   private capture paths out of public skill/PR artifacts.

--- a/skills/torch-profiler-layer-track/agents/openai.yaml
+++ b/skills/torch-profiler-layer-track/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Torch Profiler Layer Track"
+  short_description: "Add layer-number guide tracks to GPU profiler traces"
+  default_prompt: "Use $torch-profiler-layer-track to add verified layer-number guide tracks to my local Torch Profiler trace."

--- a/skills/torch-profiler-layer-track/references/navigation.md
+++ b/skills/torch-profiler-layer-track/references/navigation.md
@@ -1,0 +1,115 @@
+# Layer navigation and evidence
+
+## What to count
+
+A model-specific, once-per-layer anchor is necessary. Check the exact build's
+call site; fused kernels may change names or remove earlier anchors. A kernel
+can run once per attention/FFN half, once per request, or once per draft stage.
+Those are not interchangeable with one occurrence per transformer layer.
+
+For DeepSeek-V4.1 in the examined optimized build, `_q_rope_store` occurred
+40 times per target verify and 800 times over 20 iterations. Draft used another
+RoPE path. The main-model MoE finalize kernel with six routed experts gave a
+second 800-event landmark; draft used three routed experts. These are evidence
+from one build, not built-in detection rules. Ordinary-decode, older builds,
+other tensor-parallel sizes, and fused successors must be rechecked.
+
+Example after verifying those conditions in the supplied trace:
+
+```bash
+python3 scripts/add_layer_track.py \
+  --trace /path/to/optimized.trace.json \
+  --output /path/to/optimized.layers.trace.json \
+  --anchor-regex '^_q_rope_store$' \
+  --end-anchor-regex 'moe_finalize_all_reduce_kernel<4u, 5120u, 6u' \
+  --num-layers 40 --anchor-offset 0 --passes 20 \
+  --phase target-verify \
+  --evidence 'Matching source confirms one Q-store per target layer; 800 Q stores and 800 main MoE finalizers; first anchor verified as L0; draft uses a distinct path.'
+```
+
+The finalizer regex is intentionally build-specific. Terminal validation
+requires exactly one match between each pair of anchors. A mismatch must be
+investigated, not bypassed by shortening the model layer count until it fits.
+For a partial capture, locate the first complete pass and set the offset.
+The report's `pass_index` is relative to the selected subset, not necessarily
+an absolute scheduler iteration number.
+
+## Interpreting the track
+
+`L0` is the first transformer layer; `L20` is the twenty-first. A guide spans
+`anchor(Li)` to `anchor(Li+1)`. It may contain later work from Li and work from
+Li+1 that precedes its anchor. A single layer can submit to several streams;
+an event geometrically underneath a label is not sufficient proof of ownership.
+Use call sites and CPU/GPU correlation flows for exact attribution. CUDA Graph
+replay can lack per-op CPU launches; a separately captured warmup trace may
+help identify call sites, but its timings cannot replace steady-state timings.
+
+Do not:
+
+- Count every Top-K launch as a layer; one logical selection can launch several
+  kernels, and some layers do no index selection at all.
+- Count one entire repeated target/draft cluster as a layer.
+- Interpret CPU `record_function` duration as GPU execution duration.
+- Stretch the last layer to the next iteration's first anchor.
+- Shift or crop original timestamps merely to make an image easier to label.
+
+## Time units and import checks
+
+Chrome JSON `ts` and `dur` are in **microseconds**, regardless of the optional
+`displayTimeUnit` presentation setting. Perfetto SQL `ts` and `dur` are in
+**nanoseconds**. The report's relative milliseconds subtract the minimum
+finite original event timestamp. Compare this origin with `trace_bounds`
+before assuming it is the exact UI zero.
+
+Very large floating-point timestamps can introduce 1 ns overlaps when a guide
+duration is subtracted in Python and converted to ns by Perfetto. The helper
+rounds auxiliary endpoints to integer microseconds (at most 0.5 us adjustment),
+keeping the guide on one flat track. Original events are untouched; the report
+includes both anchor timestamps and the rounded guide endpoints.
+
+Useful SQL after opening the annotated trace (also works with the official
+Trace Processor Python API):
+
+```sql
+SELECT name, count(*) AS occurrences
+FROM slice WHERE category = 'layer_guide'
+GROUP BY name ORDER BY CAST(substr(name, 2) AS INT);
+
+SELECT s.name, s.ts, s.dur, t.name AS track
+FROM slice s JOIN track t ON t.id = s.track_id
+WHERE s.category = 'layer_guide' ORDER BY s.ts;
+```
+
+Expect `num_layers * passes` slices; each layer appears `passes` times. Zero
+last-layer duration is intentional without a terminal anchor. Compare original
+and annotated JSON event arrays and top-level metadata to verify preservation.
+For a CPU/GPU trace, check CPU event categories and flow events too. This helper
+loads the JSON in memory; for multi-GB traces, use an existing Trace Processor
+and a SQL debug track rather than exhausting local memory with a rewrite.
+
+## Browser viewing and screenshots
+
+The auxiliary track is stored in the trace itself. Manual **Open trace file**
+is the simplest path. Pin the guide next to the selected GPU streams, then zoom
+into one pass until labels are readable. Keep stream labels and the time axis
+visible. Capture one overview and a tighter view when the requested layers
+cannot fit legibly together. Capture the real viewer, not a recreated timeline.
+
+If using `serve_local_trace.py`, open its loopback URL in the requested browser.
+The page loads the public Perfetto UI and sends the bytes from its single local
+`/trace` endpoint via `postMessage`. A PING/PONG handshake prevents lost messages
+while the UI initializes. A “Local trace sent” status confirms transfer only;
+verify the actual timeline has loaded. Keep the server running while viewing.
+No OS accessibility permission changes or browser profile edits are needed.
+
+For direct browser automation, use available authorized browser tools or an
+isolated automation profile. Respect the user's choice of browser for the
+final view. If the UI cannot be inspected, report that limitation instead of
+claiming a screenshot was visually verified.
+
+Official references:
+
+- [Chrome JSON trace import](https://perfetto.dev/docs/getting-started/other-formats)
+- [Embedding the Perfetto UI](https://perfetto.dev/docs/visualization/embedding-the-ui)
+- [Embedding API reference](https://perfetto.dev/docs/visualization/embedding-api-reference)
+- [Trace Processor Python API](https://perfetto.dev/docs/analysis/trace-processor-python)

--- a/skills/torch-profiler-layer-track/scripts/add_layer_track.py
+++ b/skills/torch-profiler-layer-track/scripts/add_layer_track.py
@@ -1,0 +1,297 @@
+"""Append layer guide slices to Chrome JSON without changing recorded events."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+
+CATEGORY = "layer_guide"
+NOTICE = (
+    "Anchor-to-anchor navigation guides, not full layer spans or exclusive "
+    "kernel ownership. The last layer ends at a verified terminal kernel, "
+    "or is a point marker without a terminal. Chrome timestamps are us."
+    " Only guide endpoints are rounded to the nearest us to avoid floating-point overlap."
+)
+
+
+def read_trace(path):
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def event_list(document):
+    events = document if isinstance(document, list) else document.get("traceEvents")
+    if not isinstance(events, list):
+        raise ValueError("Expected a Chrome event array or an object with traceEvents")
+    return events
+
+
+def finite_time(value):
+    return isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def annotate(
+    document,
+    *,
+    anchor_regex,
+    num_layers,
+    anchor_offset,
+    passes,
+    phase,
+    evidence,
+    pid=None,
+    device=None,
+    first_layer=0,
+    end_anchor_regex=None,
+):
+    if num_layers < 1 or passes < 1 or anchor_offset < 0 or first_layer < 0:
+        raise ValueError(
+            "Layer/pass counts must be positive; offsets must be nonnegative"
+        )
+    if not evidence.strip() or not phase.strip():
+        raise ValueError(
+            "Supply a phase and evidence establishing the first layer/anchor"
+        )
+    events = event_list(document)
+    if any(e.get("cat") == CATEGORY for e in events):
+        raise ValueError(
+            "Trace already has a layer guide; start from the original trace"
+        )
+    pattern = re.compile(anchor_regex)
+    kernels = [
+        e
+        for e in events
+        if e.get("ph") == "X" and "kernel" in e.get("cat", "").split(",")
+    ]
+    anchors = [e for e in kernels if pattern.search(e.get("name", ""))]
+    if pid is not None:
+        anchors = [e for e in anchors if str(e.get("pid")) == str(pid)]
+    if device is not None:
+        anchors = [
+            e for e in anchors if str(e.get("args", {}).get("device")) == str(device)
+        ]
+    pids = {e.get("pid") for e in anchors}
+    if len(pids) != 1 or None in pids:
+        raise ValueError(
+            f"Expected one anchor PID, found {sorted(map(str, pids))}; use --pid"
+        )
+    selected_pid = next(iter(pids))
+    kernels = [e for e in kernels if e.get("pid") == selected_pid]
+    devices = {e.get("args", {}).get("device") for e in anchors}
+    if len(devices) > 1:
+        raise ValueError(
+            "Matching anchors span multiple devices in one PID; use --device"
+        )
+    selected_device = next(iter(devices))
+    if selected_device is not None:
+        kernels = [
+            e for e in kernels if e.get("args", {}).get("device") == selected_device
+        ]
+    if any(
+        not finite_time(e.get("ts")) or not finite_time(e.get("dur")) or e["dur"] < 0
+        for e in kernels
+    ):
+        raise ValueError("Selected GPU contains invalid kernel timestamps/durations")
+    anchors.sort(key=lambda e: e["ts"])
+    count = num_layers * passes
+    selected = anchors[anchor_offset : anchor_offset + count]
+    if len(selected) != count:
+        raise ValueError(
+            f"Need {count} anchors from offset {anchor_offset}; found {len(selected)}"
+        )
+    if any(a["ts"] >= b["ts"] for a, b in zip(selected, selected[1:])):
+        raise ValueError("Anchors must have distinct increasing timestamps")
+    terminal_pattern = re.compile(end_anchor_regex) if end_anchor_regex else None
+    terminals = [
+        e for e in kernels if terminal_pattern and terminal_pattern.search(e["name"])
+    ]
+    existing_tids = {str(e.get("tid")) for e in events if e.get("pid") == selected_pid}
+    guide_tid = 1_000_000
+    while str(guide_tid) in existing_tids:
+        guide_tid += 1
+    track_name = f"Layer guide ({phase}) — anchor intervals"
+    added = [
+        {
+            "ph": "M",
+            "name": "thread_name",
+            "pid": selected_pid,
+            "tid": guide_tid,
+            "args": {"name": track_name},
+        },
+        {
+            "ph": "M",
+            "name": "thread_sort_index",
+            "pid": selected_pid,
+            "tid": guide_tid,
+            "args": {"sort_index": -1000},
+        },
+    ]
+    origin = min(e["ts"] for e in events if finite_time(e.get("ts")))
+    rows = []
+    for index, anchor in enumerate(selected):
+        pass_id, layer_index = divmod(index, num_layers)
+        layer_id = first_layer + layer_index
+        global_index = anchor_offset + index
+        next_anchor = (
+            anchors[global_index + 1] if global_index + 1 < len(anchors) else None
+        )
+        upper = next_anchor["ts"] if next_anchor else math.inf
+        terminal = None
+        if terminal_pattern:
+            matches = [e for e in terminals if anchor["ts"] <= e["ts"] < upper]
+            if len(matches) != 1:
+                raise ValueError(
+                    f"Pass {pass_id} L{layer_id}: expected one terminal, found {len(matches)}"
+                )
+            terminal = matches[0]
+            if terminal["ts"] + terminal["dur"] > upper:
+                raise ValueError(
+                    f"Pass {pass_id} L{layer_id}: terminal overlaps next anchor"
+                )
+        if layer_index < num_layers - 1:
+            end, boundary = selected[index + 1]["ts"], "next_layer_anchor"
+        elif terminal:
+            end, boundary = terminal["ts"] + terminal["dur"], "terminal_kernel_end"
+        else:
+            end, boundary = anchor["ts"], "anchor_point_only"
+        # Large epoch-like timestamps lose sub-us precision during subtraction.
+        # Integer-us auxiliary endpoints avoid spurious 1 ns overlap in Perfetto.
+        # Original events and the exact anchor values in the report stay intact.
+        guide_start, guide_end = round(anchor["ts"]), round(end)
+        row = {
+            "pass_index": pass_id,
+            "layer_id": layer_id,
+            "anchor_index": global_index,
+            "anchor_name": anchor["name"],
+            "anchor_tid": anchor.get("tid"),
+            "start_us": anchor["ts"],
+            "end_us": end,
+            "guide_start_us": guide_start,
+            "guide_end_us": guide_end,
+            "start_relative_ms": (anchor["ts"] - origin) / 1000,
+            "end_relative_ms": (end - origin) / 1000,
+            "boundary_kind": boundary,
+        }
+        rows.append(row)
+        added.append(
+            {
+                "ph": "X",
+                "cat": CATEGORY,
+                "name": f"L{layer_id}",
+                "pid": selected_pid,
+                "tid": guide_tid,
+                "ts": guide_start,
+                "dur": guide_end - guide_start,
+                "args": {**row, "phase": phase, "evidence": evidence, "notice": NOTICE},
+            }
+        )
+    output_events = events + added
+    output = (
+        output_events
+        if isinstance(document, list)
+        else {**document, "traceEvents": output_events}
+    )
+    report = {
+        "schema_version": 1,
+        "notice": NOTICE,
+        "phase": phase,
+        "evidence": evidence,
+        "pid": selected_pid,
+        "device": selected_device,
+        "guide_tid": guide_tid,
+        "track_name": track_name,
+        "anchor_regex": anchor_regex,
+        "end_anchor_regex": end_anchor_regex,
+        "anchor_offset": anchor_offset,
+        "matching_anchor_count": len(anchors),
+        "num_layers": num_layers,
+        "first_layer": first_layer,
+        "passes": passes,
+        "original_event_count": len(events),
+        "added_event_count": len(added),
+        "trace_origin_us": origin,
+        "layers": rows,
+    }
+    return output, report
+
+
+def write_trace(path, document):
+    # Exclusive creation also prevents replacement through existing symlinks.
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "xt", encoding="utf-8") as handle:
+        json.dump(document, handle, ensure_ascii=False, separators=(",", ":"))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--anchor-regex", required=True)
+    parser.add_argument("--num-layers", type=int, required=True)
+    parser.add_argument(
+        "--anchor-offset",
+        type=int,
+        required=True,
+        help="Index of a verified first layer in sorted anchors",
+    )
+    parser.add_argument("--passes", type=int, default=1)
+    parser.add_argument("--first-layer", type=int, default=0)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--evidence", required=True)
+    parser.add_argument("--pid")
+    parser.add_argument(
+        "--device", help="GPU device from kernel args.device, when needed"
+    )
+    parser.add_argument("--end-anchor-regex")
+    args = parser.parse_args()
+    report_path = Path(str(args.output) + ".layers.json")
+    try:
+        if (
+            args.trace.resolve() == args.output.resolve()
+            or args.output.exists()
+            or report_path.exists()
+        ):
+            raise ValueError(
+                "Choose a new output path; source/output/report files are never overwritten"
+            )
+        output, report = annotate(
+            read_trace(args.trace),
+            anchor_regex=args.anchor_regex,
+            num_layers=args.num_layers,
+            anchor_offset=args.anchor_offset,
+            passes=args.passes,
+            phase=args.phase,
+            evidence=args.evidence,
+            pid=args.pid,
+            device=args.device,
+            first_layer=args.first_layer,
+            end_anchor_regex=args.end_anchor_regex,
+        )
+        with args.trace.open("rb") as source:
+            digest = hashlib.sha256()
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+        report["source_sha256"] = digest.hexdigest()
+        report["source_file"] = args.trace.name
+        write_trace(args.output, output)
+        with report_path.open("x", encoding="utf-8") as handle:
+            json.dump(report, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+    except (OSError, ValueError, TypeError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+    print(f"Annotated trace: {args.output}")
+    print(f"Mapping report: {report_path}")
+    print(
+        f"Added {args.num_layers * args.passes} labels; original {report['original_event_count']} events retained."
+    )
+    print(NOTICE)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/torch-profiler-layer-track/scripts/serve_local_trace.py
+++ b/skills/torch-profiler-layer-track/scripts/serve_local_trace.py
@@ -1,0 +1,100 @@
+"""Serve one local trace to an embedded Perfetto UI over loopback."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def viewer_html(title):
+    safe_title = html.escape(title)
+    script_title = json.dumps(title).replace("<", "\\u003c")
+    return f"""<!doctype html>
+<meta charset="utf-8"><title>{safe_title}</title>
+<style>body{{margin:0;font-family:system-ui}}header{{padding:10px 16px}}
+iframe{{border:0;width:100%;height:85vh}}p{{margin:4px}}</style>
+<header><b>{safe_title}</b>
+<p>Pin “Layer guide” next to the GPU streams. L0 is the first layer.
+Anchor intervals are navigation guides, not full layer timings.</p>
+<p id="status">Loading Perfetto UI…</p></header>
+<iframe id="viewer" src="https://ui.perfetto.dev/#!/?mode=embedded"></iframe>
+<script>
+const frame = document.getElementById('viewer');
+const status = document.getElementById('status');
+const origin = 'https://ui.perfetto.dev';
+let sent = false;
+const timer = setInterval(() => frame.contentWindow.postMessage('PING', origin), 200);
+const timeout = setTimeout(() => {{
+  clearInterval(timer);
+  status.textContent = 'Perfetto UI did not respond. Check network access or open the trace manually.';
+}}, 60000);
+window.addEventListener('message', async event => {{
+  if (event.origin !== origin || event.source !== frame.contentWindow || event.data !== 'PONG' || sent) return;
+  sent = true; clearInterval(timer); clearTimeout(timeout);
+  try {{
+    status.textContent = 'Reading local trace…';
+    const response = await fetch('/trace');
+    if (!response.ok) throw new Error('Trace fetch failed: ' + response.status);
+    const buffer = await response.arrayBuffer();
+    frame.contentWindow.postMessage({{perfetto: {{buffer, title: {script_title}, keepApiOpen: true}}}}, origin);
+    status.textContent = 'Local trace sent. Expand the GPU/process and pin the Layer guide track.';
+  }} catch (error) {{ status.textContent = error.message; }}
+}});
+</script>
+"""
+
+
+def make_handler(trace):
+    page = viewer_html(trace.name).encode("utf-8")
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(page)))
+                self.end_headers()
+                self.wfile.write(page)
+            elif self.path == "/trace":
+                with trace.open("rb") as handle:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/octet-stream")
+                    self.send_header("Content-Length", str(trace.stat().st_size))
+                    self.end_headers()
+                    shutil.copyfileobj(handle, self.wfile)
+            else:
+                self.send_error(404)
+
+    return Handler
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument(
+        "--port", type=int, default=0, help="Default: a free loopback port"
+    )
+    args = parser.parse_args()
+    if not args.trace.is_file():
+        parser.error("Trace file does not exist")
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", args.port), make_handler(args.trace.resolve())
+    )
+    print(
+        f"Open http://127.0.0.1:{server.server_port}/ in your browser. Ctrl-C stops the server.",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repository_metadata.py
+++ b/tests/test_repository_metadata.py
@@ -16,8 +16,8 @@ def test_readme_uses_current_claude_and_codex_launch_commands() -> None:
     assert "codex --yolo" not in readme
     assert "`opus`" in readme and "current Opus" in readme
     assert "bypassPermissions" in readme and "isolated" in readme
-    assert "core_skills-11" in readme
-    assert "After reload, the 11 skills appear" in readme
+    assert "core_skills-12" in readme
+    assert "After reload, the 12 skills appear" in readme
 
 
 def test_sglang_day0_skill_is_discoverable_and_installable() -> None:
@@ -49,8 +49,8 @@ def test_marketplace_has_top_level_description() -> None:
     assert marketplace["description"]
     assert "LLM serving" in marketplace["description"]
     assert marketplace["plugins"][0]["description"]
-    assert marketplace["plugins"][0]["version"] == "0.5.0"
-    assert plugin["version"] == "0.5.0"
+    assert marketplace["plugins"][0]["version"] == "0.6.0"
+    assert plugin["version"] == "0.6.0"
     assert marketplace["plugins"][0]["version"] == plugin["version"]
     assert "Day-0" in marketplace["description"]
     assert "Day-0" in plugin["description"]

--- a/tests/test_torch_profiler_layer_track.py
+++ b/tests/test_torch_profiler_layer_track.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+import pytest
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1] / "skills/torch-profiler-layer-track/scripts"
+)
+
+
+def load_module(name):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+track = load_module("add_layer_track")
+viewer = load_module("serve_local_trace")
+
+
+def kernel(name, ts, pid=7, tid=10, dur=2):
+    return dict(ph="X", cat="kernel", name=name, ts=ts, dur=dur, pid=pid, tid=tid)
+
+
+def fixture_trace():
+    # Two passes, changing streams, draft work in the gap, CPU/flow metadata.
+    events = [
+        dict(ph="M", name="thread_name", pid=7, tid=1000000, args={"name": "occupied"}),
+        dict(ph="X", cat="cpu_op", name="CPU scope", ts=90, dur=400, pid=42, tid=1),
+        dict(ph="s", cat="forward_backward", name="flow", ts=95, pid=42, tid=1, id=3),
+    ]
+    for start in (100, 400):
+        for layer in range(3):
+            events += [
+                kernel("anchor", start + layer * 20, tid=10 + layer),
+                kernel("terminal", start + layer * 20 + 10, tid=12 - layer),
+            ]
+    events.append(kernel("draft", 250, dur=30))
+    return {
+        "schemaVersion": 1,
+        "displayTimeUnit": "ms",
+        "custom": {"keep": True},
+        "traceEvents": list(reversed(events)),
+    }
+
+
+def annotate(document, **overrides):
+    args = dict(
+        anchor_regex="^anchor$",
+        num_layers=3,
+        anchor_offset=0,
+        passes=2,
+        phase="target-verify",
+        evidence="fixture source: once per layer; first L0 verified",
+        end_anchor_regex="^terminal$",
+    )
+    return track.annotate(document, **(args | overrides))
+
+
+def test_preserves_events_and_metadata_and_does_not_label_draft_gap():
+    original = fixture_trace()
+    before = copy.deepcopy(original)
+    result, report = annotate(original)
+    count = len(before["traceEvents"])
+    assert original == before
+    assert result["traceEvents"][:count] == before["traceEvents"]
+    assert {k: v for k, v in result.items() if k != "traceEvents"} == {
+        k: v for k, v in before.items() if k != "traceEvents"
+    }
+    markers = [e for e in result["traceEvents"] if e.get("cat") == "layer_guide"]
+    assert [(e["name"], e["ts"], e["dur"]) for e in markers] == [
+        ("L0", 100, 20),
+        ("L1", 120, 20),
+        ("L2", 140, 12),
+        ("L0", 400, 20),
+        ("L1", 420, 20),
+        ("L2", 440, 12),
+    ]
+    assert report["guide_tid"] == 1000001
+    assert report["layers"][0]["start_relative_ms"] == 0.01
+    assert [r["anchor_tid"] for r in report["layers"]] == [10, 11, 12] * 2
+
+
+def test_point_last_layer_and_known_partition_offset():
+    result, report = annotate(
+        fixture_trace()["traceEvents"],
+        anchor_offset=3,
+        passes=1,
+        first_layer=20,
+        end_anchor_regex=None,
+    )
+    assert isinstance(result, list)
+    assert [r["layer_id"] for r in report["layers"]] == [20, 21, 22]
+    assert report["layers"][-1]["start_us"] == report["layers"][-1]["end_us"] == 440
+    assert report["layers"][-1]["boundary_kind"] == "anchor_point_only"
+
+
+def test_large_fractional_timestamps_do_not_overlap_on_guide():
+    original = fixture_trace()
+    for event in original["traceEvents"]:
+        if "ts" in event:
+            event["ts"] += 6148459900000.927
+    output, _ = annotate(original)
+    markers = [e for e in output["traceEvents"] if e.get("cat") == "layer_guide"]
+    assert all(isinstance(e["ts"], int) and isinstance(e["dur"], int) for e in markers)
+    assert all(a["ts"] + a["dur"] <= b["ts"] for a, b in zip(markers, markers[1:]))
+    assert (
+        output["traceEvents"][: len(original["traceEvents"])] == original["traceEvents"]
+    )
+
+
+def test_requires_rank_selection_and_ignores_other_rank():
+    original = fixture_trace()
+    original["traceEvents"].append(kernel("anchor", 100, pid=8))
+    with pytest.raises(ValueError, match="one anchor PID"):
+        annotate(original)
+    result, report = annotate(original, pid="7")
+    assert report["pid"] == 7
+    assert kernel("anchor", 100, pid=8) in result["traceEvents"]
+
+
+def test_multiple_devices_in_one_pid_need_selection():
+    original = fixture_trace()
+    kernels = [e for e in original["traceEvents"] if e.get("cat") == "kernel"]
+    for e in kernels:
+        e["args"] = {"device": 0}
+    other_device = copy.deepcopy(kernels)
+    for e in other_device:
+        e["args"]["device"] = 1
+    original["traceEvents"] += other_device
+    with pytest.raises(ValueError, match="multiple devices"):
+        annotate(original)
+    output, report = annotate(original, device="0")
+    assert report["device"] == 0
+    assert report["matching_anchor_count"] == 6
+    assert (
+        output["traceEvents"][: len(original["traceEvents"])] == original["traceEvents"]
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"passes": 3}, "Need 9 anchors"),
+        ({"anchor_regex": "^missing$"}, "one anchor PID"),
+        ({"end_anchor_regex": "^missing$"}, "expected one terminal"),
+        ({"anchor_offset": -1}, "offsets"),
+        ({"evidence": ""}, "evidence"),
+    ],
+)
+def test_rejects_unverifiable_selections(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        annotate(fixture_trace(), **overrides)
+
+
+def test_rejects_duplicate_anchors_and_ambiguous_terminals():
+    original = fixture_trace()
+    original["traceEvents"].append(kernel("anchor", 100))
+    with pytest.raises(ValueError, match="distinct"):
+        annotate(original)
+    original = fixture_trace()
+    original["traceEvents"].append(kernel("terminal", 111))
+    with pytest.raises(ValueError, match="expected one terminal"):
+        annotate(original)
+    original = fixture_trace()
+    original["traceEvents"].append(kernel("terminal", 390, dur=20))
+    with pytest.raises(ValueError, match="expected one terminal"):
+        annotate(original)
+    result, _ = annotate(fixture_trace())
+    with pytest.raises(ValueError, match="already has"):
+        annotate(result)
+
+
+def test_rejects_terminal_crossing_next_layer():
+    original = fixture_trace()
+    for e in original["traceEvents"]:
+        if e.get("name") == "terminal" and e["ts"] == 110:
+            e["dur"] = 20
+    with pytest.raises(ValueError, match="overlaps"):
+        annotate(original)
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_cli_round_trip_and_refuses_overwrite(tmp_path, compressed):
+    source = tmp_path / ("source.json.gz" if compressed else "source.json")
+    output = tmp_path / ("output.json.gz" if compressed else "output.json")
+    original = fixture_trace()
+    track.write_trace(source, original)
+    command = [
+        sys.executable,
+        str(SCRIPTS / "add_layer_track.py"),
+        "--trace",
+        str(source),
+        "--output",
+        str(output),
+        "--anchor-regex",
+        "^anchor$",
+        "--num-layers",
+        "3",
+        "--anchor-offset",
+        "0",
+        "--passes",
+        "2",
+        "--phase",
+        "target-verify",
+        "--evidence",
+        "verified fixture",
+        "--end-anchor-regex",
+        "^terminal$",
+    ]
+    subprocess.run(command, check=True, capture_output=True)
+    assert (
+        track.read_trace(output)["traceEvents"][: len(original["traceEvents"])]
+        == original["traceEvents"]
+    )
+    assert track.read_trace(source) == original
+    report = json.loads(Path(str(output) + ".layers.json").read_text())
+    assert len(report["source_sha256"]) == 64
+    assert report["added_event_count"] == 8
+    before = output.read_bytes()
+    assert subprocess.run(command, capture_output=True).returncode != 0
+    assert output.read_bytes() == before
+    with pytest.raises(FileExistsError):
+        track.write_trace(source, {})
+
+
+def test_local_server_only_exposes_viewer_and_exact_trace(tmp_path):
+    trace = tmp_path / "trace.json"
+    trace.write_bytes(b'{"traceEvents":[]}')
+    server = ThreadingHTTPServer(("127.0.0.1", 0), viewer.make_handler(trace))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_port}"
+    try:
+        assert urlopen(base + "/trace").read() == trace.read_bytes()
+        assert b"PING" in urlopen(base).read()
+        with pytest.raises(HTTPError) as error:
+            urlopen(base + "/../secret")
+        assert error.value.code == 404
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+    page = viewer.viewer_html("</script><script>alert(1)</script>")
+    assert "</script><script>alert(1)</script>" not in page


### PR DESCRIPTION
Adds `torch-profiler-layer-track` to label transformer layers beside GPU kernels in Perfetto. Given a verified once-per-layer anchor, the helper writes L0…Ln guide slices into a new Chrome JSON trace and a mapping report, preserving all original CPU/GPU events and metadata. A loopback viewer loads local trace bytes into the Perfetto UI.

The skill explains how to establish a complete pass, separate target verify from draft, choose a rank/device, and distinguish anchor intervals from full layer boundaries. The helper rejects incomplete selections and ambiguous rank/device or terminal matches, avoids labeling the draft gap as the final layer, and rounds only auxiliary endpoints to integer microseconds to prevent spurious 1 ns overlaps at large timestamps. JSON and gzip input/output are supported; existing files are never overwritten.

Registers the skill in the README/install examples and bumps the plugin to 0.6.0.

Validation:
- 22 tests passed: annotation/metadata preservation, changing streams, multiple ranks/devices, incomplete selections, duplicate anchors, terminal boundaries, large timestamps, gzip/JSON CLI round trips, overwrite protection, loopback routes, and repository metadata.
- Skill validator and all pre-commit hooks for changed files passed.
- Real DeepSeek-V4.1 trace: 20 target passes × 40 layers → 800 guide slices. All 90,896 original events and top-level metadata compare equal; all 40,673 GPU kernels remain.
- Perfetto Trace Processor imported all 800 labels at depth 0. Existing trace import warnings remained unchanged (9,108); no new warnings from annotation.
- Real browser smoke: the local viewer transferred the trace, the GPU process expanded to show the layer guide next to its streams, and the timeline was visually checked at readable layer scale.

Raw traces and private local paths are not included in this PR. These labels are navigation aids, not measurements of complete layer latency.
